### PR TITLE
fix condition to test VM absence

### DIFF
--- a/upgrade-prechecks/preupgrade-healthcheck.sh
+++ b/upgrade-prechecks/preupgrade-healthcheck.sh
@@ -664,8 +664,8 @@ function isAuthCorrect () {
 #clusters-devcluster-414   devcluster-414-598f1ac6-nfmtd   3d23h   Running   True
 #clusters-scale-414        scale-414-7eec1c0e-n9gmj        2d15h   Running   True
 function get_virtual_machines () {
-  oc get virtualmachine -A 2>&1 >> /dev/null
-  if [[ $? -ne 0 ]]; then
+  vms=$(oc get virtualmachine -A 2>&1 >> /dev/null)
+  if [[ "${vms}" == "No resources found" ]]; then
     print info "${CHECK_PASS} There are no virtual machines on this cluster, so there is no need to continue this check."
     return 0
   fi


### PR DESCRIPTION
test result from where VM is not there

```
 ./preupgrade-healthcheck.sh 
======================================================================================
Started healthcheck for IBM Storage Fusion HCI cluster at 2023-12-21 -0500 04:48:43 AM
======================================================================================

======================================================================================
			****** API access ******
======================================================================================

INFO: Verify Red Hat OpenShift API access.
INFO:   ✅ Red Hat OpenShift API is accessible.

======================================================================================
			****** Registry access ******
======================================================================================

Starting pod/control-1-ru2rackm12mydomaincom-debug ...
To use host binaries, run `chroot /host`

Removing debug pod ...
INFO:   ✅ quay.io is accessible.

======================================================================================

Starting pod/control-1-ru2rackm12mydomaincom-debug ...
To use host binaries, run `chroot /host`

Removing debug pod ...
INFO:   ✅ cp.icr.io is accessible.

======================================================================================

Starting pod/control-1-ru2rackm12mydomaincom-debug ...
To use host binaries, run `chroot /host`

Removing debug pod ...
INFO:   ✅ icr.io is accessible.

======================================================================================
			****** Registry authentication and authorisation ******
======================================================================================

Starting pod/control-1-ru2rackm12mydomaincom-debug ...
To use host binaries, run `chroot /host`
Writing manifest to image destination

Removing debug pod ...
INFO:   ✅ successfully able to pull ISF images.

======================================================================================

Starting pod/control-1-ru2rackm12mydomaincom-debug ...
To use host binaries, run `chroot /host`
Writing manifest to image destination

Removing debug pod ...
INFO:   ✅ successfully able to pull image from OpenShift quay.io.

======================================================================================
			****** Cluster operators ******
======================================================================================

INFO: Verify Red Hat OpenShift cluster operators health.
INFO:   ✅ All Red Hat OpenShift cluster operators are healthy.

======================================================================================
			****** Nodes ******
======================================================================================

INFO: Verify Red Hat OpenShift nodes status.
INFO:   ✅ All Red Hat OpenShift nodes are Ready.

======================================================================================
			****** Machine configuration pools ******
======================================================================================

INFO: Verify machine config pools are updated.

======================================================================================

INFO:   ✅ All machine configuration pools are upto date.

======================================================================================
			****** Catalog sources ******
======================================================================================

INFO: Verify catalog sources health in cluster.
INFO:   ✅ All catalog sources are ready.

======================================================================================
			****** Fusion software ******
======================================================================================

INFO: Verify IBM Storage Fusion health.

======================================================================================
			****** Backup & Restore ******
======================================================================================

INFO: Verify IBM Storage Fusion Data protection health.
INFO:   ✅ All operators for data protection are healthy.

======================================================================================

INFO:   ✅ All pods for data protection are healthy.

======================================================================================

INFO:   ✅ All PVCs for data protection are bound.

======================================================================================
			****** Legacy SPP ******
======================================================================================

INFO: Verify IBM Storage Fusion legacy SPP health.
INFO:   ✅ All pods for SPP server are healthy.

======================================================================================

INFO:   ✅ All PVCs for SPP server are bound.

======================================================================================

INFO:   ✅ All pods for SPP agent are healthy.

======================================================================================

INFO:   ✅ All PVCs for SPP agent are bound.

======================================================================================
			****** Data Classification ******
======================================================================================

INFO: Verify Data classification service health.
INFO:   ✅ All operators for DCS are healthy.

======================================================================================

INFO:   ✅ All pods for DCS  are healthy.

======================================================================================

INFO:   ✅ All PVCs for DCS are bound.

======================================================================================
			****** Scale cluster ******
======================================================================================

INFO: Verify IBM Storage Scale operator pod status.
INFO:   ✅ IBM Storage Scale operator is healthy.

======================================================================================

INFO: Verify IBM Storage Scale daemon pods status.
INFO:   ✅ All of IBM Storage Scale daemon pods are healthy.

======================================================================================

INFO: Verify IBM Storage Scale dns pods status.
INFO:   ✅ All IBM Storage Scale dns pods are healthy.

======================================================================================

INFO: Verify IBM Storage Scale csi pods status.
INFO:   ✅ All IBM Storage Scale CSI pods are healthy.

======================================================================================

INFO: Verify IBM Storage Scale health
Defaulting container name to gpfs.
Use 'oc describe pod/control-1-ru2 -n ibm-spectrum-scale' to see all of the containers in this pod.
INFO:   ✅ All of IBM Storage Scale components are healthy.

======================================================================================
			****** VMs migration ******
======================================================================================

INFO:   ✅ There are no virtual machines on this cluster, so there is no need to continue this check.

======================================================================================
			****** Pods with imagepullbackoff across cluster ******
======================================================================================

INFO: Verify unhealthy pods across cluster.
ERROR:   ❌ Below pods in this cluster are unhealthy.
minio                                              minio-5794769cc9-gfr7f                                              0/1     ImagePullBackOff   0               24h

======================================================================================
			****** Nodes hardware status ******
======================================================================================

INFO: Verify node hardware status
INFO:   ✅ All configured nodes hardware is healthy.

======================================================================================
			****** Fusion nodes maintenance ******
======================================================================================

INFO: Verify if any node is under fusion maintenance
INFO:   ✅ No node is under fusion maintenance.

======================================================================================
			****** Network checks ******
======================================================================================

INFO: Verify DNS on nodes
Starting pod/compute-1-ru5rackm12mydomaincom-debug ...
To use host binaries, run `chroot /host`

Removing debug pod ...
INFO:   ✅ DNS is configured correctly on compute-1-ru5.rackm12.mydomain.com.
Starting pod/compute-1-ru6rackm12mydomaincom-debug ...
To use host binaries, run `chroot /host`

Removing debug pod ...
INFO:   ✅ DNS is configured correctly on compute-1-ru6.rackm12.mydomain.com.
Starting pod/compute-1-ru7rackm12mydomaincom-debug ...
To use host binaries, run `chroot /host`

Removing debug pod ...
INFO:   ✅ DNS is configured correctly on compute-1-ru7.rackm12.mydomain.com.
Starting pod/control-1-ru2rackm12mydomaincom-debug ...
To use host binaries, run `chroot /host`

Removing debug pod ...
INFO:   ✅ DNS is configured correctly on control-1-ru2.rackm12.mydomain.com.
Starting pod/control-1-ru3rackm12mydomaincom-debug ...
To use host binaries, run `chroot /host`

Removing debug pod ...
INFO:   ✅ DNS is configured correctly on control-1-ru3.rackm12.mydomain.com.
Starting pod/control-1-ru4rackm12mydomaincom-debug ...
To use host binaries, run `chroot /host`

Removing debug pod ...
INFO:   ✅ DNS is configured correctly on control-1-ru4.rackm12.mydomain.com.

======================================================================================

INFO: Verify Link
INFO:   ✅ Link rackm12-links is healthy.

======================================================================================

INFO: Verify switch
INFO:   ✅ Switch hspeed1-rackm12 is healthy.
INFO:   ✅ Switch hspeed2-rackm12 is healthy.
INFO:   ✅ Switch mgmt1-rackm12 is healthy.
INFO:   ✅ Switch mgmt2-rackm12 is healthy.

======================================================================================

INFO: Verify vlan
INFO:   ✅ vlan "3201" is heathy.
INFO:   ✅ vlan "4091" is heathy.
INFO:   ✅ vlan "1" is heathy.
INFO:   ✅ vlan "12" is heathy.

========================================================================================
Healthcheck for IBM Storage Fusion HCI cluster completed at 2023-12-21 -0500 04:49:20 AM
========================================================================================

```