### PR TITLE
Use job name instead of job id

### DIFF
--- a/backup-restore/recipes/getRecipeWorkflow.sh
+++ b/backup-restore/recipes/getRecipeWorkflow.sh
@@ -48,7 +48,14 @@ if [[ -n $2 ]]; then
 	fi
 
 	fusionNs=$(oc get spectrumfusion -A --no-headers | cut -d" " -f1)
-        [[ -v job_name ]] && job_uid=$(oc get f$job_type $job_name -n $fusionNs -o json | jq '.metadata.uid' | tr -d '"')
+        uname=$(uname)
+        case "$uname" in
+          "Darwin")
+             [[ "${job_name}" ]] && job_uid=$(oc get f$job_type $job_name -n $fusionNs -o json | jq '.metadata.uid' | tr -d '"') ;;
+          "Linux")
+             [ "${job_name+set}" ] && job_uid=$(oc get f$job_type $job_name -n $fusionNs -o json | jq '.metadata.uid' | tr -d '"') ;;
+          *) echo "Error: Unsupported platform $uname"; exit 1; ;;
+        esac
 	brNs=$(oc -n "$fusionNs" get fusionserviceinstance ibm-backup-restore-service-instance -o json |jq -rc '[(.spec.parameters[]|"\n",.name,.value)]|@csv' | tr -d '"' | grep ",namespace," | cut -d"," -f3)
 
 	if [[ -z "$brNs" ]]; then

--- a/backup-restore/recipes/getRecipeWorkflow.sh
+++ b/backup-restore/recipes/getRecipeWorkflow.sh
@@ -48,14 +48,7 @@ if [[ -n $2 ]]; then
 	fi
 
 	fusionNs=$(oc get spectrumfusion -A --no-headers | cut -d" " -f1)
-        uname=$(uname)
-        case "$uname" in
-          "Darwin")
-             [[ "${job_name}" ]] && job_uid=$(oc get f$job_type $job_name -n $fusionNs -o json | jq '.metadata.uid' | tr -d '"') ;;
-          "Linux")
-             [ "${job_name+set}" ] && job_uid=$(oc get f$job_type $job_name -n $fusionNs -o json | jq '.metadata.uid' | tr -d '"') ;;
-          *) echo "Error: Unsupported platform $uname"; exit 1; ;;
-        esac
+        [ "${job_name+set}" ] && job_uid=$(oc get f$job_type $job_name -n $fusionNs -o json | jq '.metadata.uid' | tr -d '"')
 	brNs=$(oc -n "$fusionNs" get fusionserviceinstance ibm-backup-restore-service-instance -o json |jq -rc '[(.spec.parameters[]|"\n",.name,.value)]|@csv' | tr -d '"' | grep ",namespace," | cut -d"," -f3)
 
 	if [[ -z "$brNs" ]]; then

--- a/backup-restore/recipes/getRecipeWorkflow.sh
+++ b/backup-restore/recipes/getRecipeWorkflow.sh
@@ -1,7 +1,43 @@
 #!/bin/bash
 # This script returns recipe workflow logs of a backup or restore job in IBM Storage Fusion Backup & Restore service.
-# Usage: getRecipeWorkflow.sh (backup | restore) <job id>
-# 	 e.g. getRecipeWorkflow.sh backup 9c1e7f2d-fd74-4bcc-b28e-6cb82785913a
+# Usage: getResources.sh (backup | restore) <job uid | -n job name>
+#        example -
+#        getResources.sh backup 9c1e7f2d-fd74-4bcc-b28e-6cb82785913a
+#        getResources.sh backup -n filebrowser-filebrowser-policy-apps.hostname-202402161744
+
+usage() {
+    echo "Usage: $0 (backup | restore) <job_uid | -n job_name>"
+    exit 1
+}
+
+[[ "$1" = "-h" ]] && usage
+if [ "$#" -lt 2 ] || [ "$#" -gt 3 ]; then
+  echo "Error: Command line args not in range 2 and 3"
+  usage
+fi
+
+case $1 in
+    "backup"|"restore")
+    job_type=$1
+        if [ "$2" = "-n" ]; then
+            option=$2
+            if [ -z "$3" ]; then
+                echo "Error: Job name is missing"
+                usage
+            fi
+            job_name=$3
+        elif [[ "$2" =~ ^-.* ]]; then
+            echo "Error: Invalid option $2"
+            usage
+        else
+            job_uid=$2
+        fi
+        ;;
+    *)
+        echo "Error: Unknown command: $1"
+        usage
+        ;;
+esac
 
 if [[ -n $2 ]]; then
 
@@ -12,8 +48,9 @@ if [[ -n $2 ]]; then
 	fi
 
 	fusionNs=$(oc get spectrumfusion -A --no-headers | cut -d" " -f1)
+        [[ -v job_name ]] && job_uid=$(oc get f$job_type $job_name -n $fusionNs -o json | jq '.metadata.uid' | tr -d '"')
 	brNs=$(oc -n "$fusionNs" get fusionserviceinstance ibm-backup-restore-service-instance -o json |jq -rc '[(.spec.parameters[]|"\n",.name,.value)]|@csv' | tr -d '"' | grep ",namespace," | cut -d"," -f3)
-	
+
 	if [[ -z "$brNs" ]]; then
 		echo "Error: Backup & Restore service not found";exit
 	fi
@@ -24,10 +61,10 @@ if [[ -n $2 ]]; then
 		echo "Error: Backup-service pod is not running";exit
 	fi
 
-	oc exec -it $podName -n $brNs -- curl -k https://backup-service:9443/dataprotection/backup-service/v1/logs/$2/recipe$queryParam | jq
+	oc exec -it $podName -n $brNs -- curl -k https://backup-service:9443/dataprotection/backup-service/v1/logs/$job_uid/recipe$queryParam | jq
 
 	echo "===== Log format ====="
-	oc exec -it $podName -n $brNs -- curl -k https://backup-service:9443/dataprotection/backup-service/v1/logs/$2/recipe$queryParam | jq -r '[.logs] | @sh' 
+	oc exec -it $podName -n $brNs -- curl -k https://backup-service:9443/dataprotection/backup-service/v1/logs/$job_uid/recipe$queryParam | jq -r '[.logs] | @sh'
 else
 	echo "Usage: " $0 " (backup | restore) <job id>"
 fi

--- a/backup-restore/recipes/getRecipeWorkflow.sh
+++ b/backup-restore/recipes/getRecipeWorkflow.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 # This script returns recipe workflow logs of a backup or restore job in IBM Storage Fusion Backup & Restore service.
-# Usage: getResources.sh (backup | restore) <job uid | -n job name>
+# Usage: getRecipeWorkflow.sh (backup | restore) <job uid | -n job name>
 #        example -
-#        getResources.sh backup 9c1e7f2d-fd74-4bcc-b28e-6cb82785913a
-#        getResources.sh backup -n filebrowser-filebrowser-policy-apps.hostname-202402161744
+#        getRecipeWorkflow.sh backup 9c1e7f2d-fd74-4bcc-b28e-6cb82785913a
+#        getRecipeWorkflow.sh backup -n filebrowser-filebrowser-policy-apps.hostname-202402161744
 
 usage() {
     echo "Usage: $0 (backup | restore) <job_uid | -n job_name>"

--- a/backup-restore/recipes/getRecipeWorkflow.sh
+++ b/backup-restore/recipes/getRecipeWorkflow.sh
@@ -66,5 +66,5 @@ if [[ -n $2 ]]; then
 	echo "===== Log format ====="
 	oc exec -it $podName -n $brNs -- curl -k https://backup-service:9443/dataprotection/backup-service/v1/logs/$job_uid/recipe$queryParam | jq -r '[.logs] | @sh'
 else
-	echo "Usage: " $0 " (backup | restore) <job id>"
+        usage
 fi

--- a/backup-restore/recipes/getResources.sh
+++ b/backup-restore/recipes/getResources.sh
@@ -47,7 +47,14 @@ if [[ -n $2 ]]; then
 	fi
 
 	fusionNs=$(oc get spectrumfusion -A --no-headers | cut -d" " -f1)
-        [[ -v job_name ]] && job_uid=$(oc get f$job_type $job_name -n $fusionNs -o json | jq '.metadata.uid' | tr -d '"')
+        uname=$(uname)
+        case "$uname" in
+          "Darwin")
+             [[ "${job_name}" ]] && job_uid=$(oc get f$job_type $job_name -n $fusionNs -o json | jq '.metadata.uid' | tr -d '"') ;;
+          "Linux")
+             [ "${job_name+set}" ] && job_uid=$(oc get f$job_type $job_name -n $fusionNs -o json | jq '.metadata.uid' | tr -d '"') ;;
+          *) echo "Error: Unsupported platform $uname"; exit 1; ;;
+        esac
         brNs=$(oc -n "$fusionNs" get fusionserviceinstance ibm-backup-restore-service-instance -o json |jq -rc '[(.spec.parameters[]|"\n",.name,.value)]|@csv' | tr -d '"' | grep ",namespace," | cut -d"," -f3)
 
         if [[ -z "$brNs" ]]; then

--- a/backup-restore/recipes/getResources.sh
+++ b/backup-restore/recipes/getResources.sh
@@ -47,14 +47,7 @@ if [[ -n $2 ]]; then
 	fi
 
 	fusionNs=$(oc get spectrumfusion -A --no-headers | cut -d" " -f1)
-        uname=$(uname)
-        case "$uname" in
-          "Darwin")
-             [[ "${job_name}" ]] && job_uid=$(oc get f$job_type $job_name -n $fusionNs -o json | jq '.metadata.uid' | tr -d '"') ;;
-          "Linux")
-             [ "${job_name+set}" ] && job_uid=$(oc get f$job_type $job_name -n $fusionNs -o json | jq '.metadata.uid' | tr -d '"') ;;
-          *) echo "Error: Unsupported platform $uname"; exit 1; ;;
-        esac
+        [ "${job_name+set}" ] && job_uid=$(oc get f$job_type $job_name -n $fusionNs -o json | jq '.metadata.uid' | tr -d '"')
         brNs=$(oc -n "$fusionNs" get fusionserviceinstance ibm-backup-restore-service-instance -o json |jq -rc '[(.spec.parameters[]|"\n",.name,.value)]|@csv' | tr -d '"' | grep ",namespace," | cut -d"," -f3)
 
         if [[ -z "$brNs" ]]; then

--- a/backup-restore/recipes/getResources.sh
+++ b/backup-restore/recipes/getResources.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # This script returns resource details that are backed up or restored by a job in IBM Storage Fusion Backup & Restore service.
-# Usage: getResources.sh (backup | restore) <job id>
-#        e.g. getResources.sh backup 9c1e7f2d-fd74-4bcc-b28e-6cb82785913a
+# Usage: getResources.sh (backup | restore) <job name>
+#        e.g. getResources.sh backup filebrowser-filebrowser-policy-apps.hostname-202402161744
 
 if [[ -n $2 ]]; then
 	if [[ $1 = "restore" ]]; then
@@ -11,6 +11,7 @@ if [[ -n $2 ]]; then
 	fi
 
 	fusionNs=$(oc get spectrumfusion -A --no-headers | cut -d" " -f1)
+        uid=$(oc get f$1 $2 -n $fusionNs -o json | jq '.metadata.uid' | tr -d '"')
     brNs=$(oc -n "$fusionNs" get fusionserviceinstance ibm-backup-restore-service-instance -o json |jq -rc '[(.spec.parameters[]|"\n",.name,.value)]|@csv' | tr -d '"' | grep ",namespace," | cut -d"," -f3)
 
     if [[ -z "$brNs" ]]; then
@@ -23,10 +24,10 @@ if [[ -n $2 ]]; then
 		echo "Error: Backup-service pod is not running";exit
     fi
 
-	oc exec -it $podName -n $brNs -- curl -k https://backup-service:9443/dataprotection/backup-service/v1/logs/$2/resources$queryParam | jq
+	oc exec -it $podName -n $brNs -- curl -k https://backup-service:9443/dataprotection/backup-service/v1/logs/$uid/resources$queryParam | jq
 
 	echo "===== CSV format ====="
-	oc exec -it $podName -n $brNs -- curl -k https://backup-service:9443/dataprotection/backup-service/v1/logs/$2/resources$queryParam | jq -r '[.logs] | @sh' 
+	oc exec -it $podName -n $brNs -- curl -k https://backup-service:9443/dataprotection/backup-service/v1/logs/$uid/resources$queryParam | jq -r '[.logs] | @sh'
 else
-	echo "Usage: " $0 " (backup | restore) <job id>"
+	echo "Usage: " $0 " (backup | restore) <job name>"
 fi

--- a/backup-restore/recipes/getResources.sh
+++ b/backup-restore/recipes/getResources.sh
@@ -1,7 +1,43 @@
 #!/bin/bash
 # This script returns resource details that are backed up or restored by a job in IBM Storage Fusion Backup & Restore service.
-# Usage: getResources.sh (backup | restore) <job name>
-#        e.g. getResources.sh backup filebrowser-filebrowser-policy-apps.hostname-202402161744
+# Usage: getResources.sh (backup | restore) <job uid | -n job name>
+#        example -
+#        getResources.sh backup 9c1e7f2d-fd74-4bcc-b28e-6cb82785913a
+#        getResources.sh backup -n filebrowser-filebrowser-policy-apps.hostname-202402161744
+
+usage() {
+    echo "Usage: $0 (backup | restore) <job_uid | -n job_name>"
+    exit 1
+}
+
+[[ "$1" = "-h" ]] && usage
+if [ "$#" -lt 2 ] || [ "$#" -gt 3 ]; then
+  echo "Error: Command line args not in range 2 and 3"
+  usage
+fi
+
+case $1 in
+    "backup"|"restore")
+    job_type=$1
+        if [ "$2" = "-n" ]; then
+            option=$2
+            if [ -z "$3" ]; then
+                echo "Error: Job name is missing"
+                usage
+            fi
+            job_name=$3
+        elif [[ "$2" =~ ^-.* ]]; then
+            echo "Error: Invalid option $2"
+            usage
+        else
+            job_uid=$2
+        fi
+        ;;
+    *)
+        echo "Error: Unknown command: $1"
+        usage
+        ;;
+esac
 
 if [[ -n $2 ]]; then
 	if [[ $1 = "restore" ]]; then
@@ -11,23 +47,23 @@ if [[ -n $2 ]]; then
 	fi
 
 	fusionNs=$(oc get spectrumfusion -A --no-headers | cut -d" " -f1)
-        uid=$(oc get f$1 $2 -n $fusionNs -o json | jq '.metadata.uid' | tr -d '"')
-    brNs=$(oc -n "$fusionNs" get fusionserviceinstance ibm-backup-restore-service-instance -o json |jq -rc '[(.spec.parameters[]|"\n",.name,.value)]|@csv' | tr -d '"' | grep ",namespace," | cut -d"," -f3)
+        [[ -v job_name ]] && job_uid=$(oc get f$job_type $job_name -n $fusionNs -o json | jq '.metadata.uid' | tr -d '"')
+        brNs=$(oc -n "$fusionNs" get fusionserviceinstance ibm-backup-restore-service-instance -o json |jq -rc '[(.spec.parameters[]|"\n",.name,.value)]|@csv' | tr -d '"' | grep ",namespace," | cut -d"," -f3)
 
-    if [[ -z "$brNs" ]]; then
-        echo "Error: Backup & Restore service not found";exit
-    fi
+        if [[ -z "$brNs" ]]; then
+            echo "Error: Backup & Restore service not found";exit
+        fi
 
 	podName=$(oc get pod -n "$brNs" --field-selector=status.phase=Running --selector=app=backup-service | grep backup-service | head -n 1 | cut -d ' ' -f1)
-	
+
 	if [[ -z "$podName" ]]; then
 		echo "Error: Backup-service pod is not running";exit
-    fi
+        fi
 
-	oc exec -it $podName -n $brNs -- curl -k https://backup-service:9443/dataprotection/backup-service/v1/logs/$uid/resources$queryParam | jq
+	oc exec -it $podName -n $brNs -- curl -k https://backup-service:9443/dataprotection/backup-service/v1/logs/$job_uid/resources$queryParam | jq
 
 	echo "===== CSV format ====="
-	oc exec -it $podName -n $brNs -- curl -k https://backup-service:9443/dataprotection/backup-service/v1/logs/$uid/resources$queryParam | jq -r '[.logs] | @sh'
+	oc exec -it $podName -n $brNs -- curl -k https://backup-service:9443/dataprotection/backup-service/v1/logs/$job_uid/resources$queryParam | jq -r '[.logs] | @sh'
 else
-	echo "Usage: " $0 " (backup | restore) <job name>"
+        usage
 fi


### PR DESCRIPTION
When working with cli I found its more friendly to use job name instead of job id.
Have verified it and its working fine.