### PR TITLE
modifying the metrodr check to cover corner case in precheck script.

### DIFF
--- a/upgrade-prechecks/preupgrade-healthcheck.sh
+++ b/upgrade-prechecks/preupgrade-healthcheck.sh
@@ -939,7 +939,7 @@ function is_metrodr_setup(){
 
 function verify_CSI_configmap_present(){
     print info "Verify presence of CSI configmap if it is a 2.6.1 MetroDR setup"
-    isfversion=$(oc get csv -n $FUSIONNS | grep isf-operator | grep "2.6.1" | wc -l)
+    isfversion=$(oc get csv -n $FUSIONNS | grep isf-operator | awk '{print $1}' | grep "2.6.1" | wc -l)
     is_metrodr_setup
     is_metrodr_setup_op=$?
     if [ "$is_metrodr_setup_op" -eq 1 ] && [ "$isfversion" -eq 1 ]; then


### PR DESCRIPTION
modifying the metrodr check to cover corner case in precheck script to validate CSI configmap in case when metrodr pairs are upgraded from 261 to 27