### PR TITLE
Remove patch of isf-application-opreator from 2.7.2.

### DIFF
--- a/backup-restore/hotfixes/2.7.2/applypatch-hci-272.sh
+++ b/backup-restore/hotfixes/2.7.2/applypatch-hci-272.sh
@@ -71,12 +71,3 @@ oc set data -n $BR_NS cm/guardian-dm-image-config DM_IMAGE=cp.icr.io/cp/fbr/guar
 echo Updating CSV $DM_CSV...
 oc patch csv -n $BR_NS $DM_CSV  --type='json' -p='[{"op":"replace", "path":"/spec/install/spec/deployments/0/spec/template/spec/containers/1/image", "value":"icr.io/cpopen/guardian-dm-operator@sha256:36df2a2cacd66f5cf8c01297728cb59dabc013d3c8d0b4eae3d8e1770f3839ec"}]'
 
-ISF_CSV=$(oc get csv -n $ISF_NS | grep "isf-operator.v2.7.2" | awk '{print $1}')
-if [[ -z ${ISF_CSV} ]]; then
-    echo "Cannot find the isf-operator.v2.7.2"
-    exit 1
-fi
-echo "Saving original to isf-operator.v2.7.2-original.yaml"
-oc get csv -n $ISF_NS ${ISF_CSV} -o yaml > isf-operator.v2.7.2-original.yaml
-echo "Updating HCI csv ${ISF_CSV}"
-oc patch csv -n $ISF_NS $ISF_CSV  --type='json' -p='[{"op":"replace", "path":"/spec/install/spec/deployments/4/spec/template/spec/containers/0/image", "value":"cp.icr.io/cp/isf/isf-application-operator@sha256:2d9b28574cb4a46ee2ff96b487d56bb395e90c8bfbbe10f0932f88ac51ece376"}]'

--- a/backup-restore/hotfixes/2.7.2/applypatch-sds-272.sh
+++ b/backup-restore/hotfixes/2.7.2/applypatch-sds-272.sh
@@ -71,12 +71,3 @@ oc set data -n $BR_NS cm/guardian-dm-image-config DM_IMAGE=cp.icr.io/cp/fbr/guar
 echo Updating CSV $DM_CSV...
 oc patch csv -n $BR_NS $DM_CSV  --type='json' -p='[{"op":"replace", "path":"/spec/install/spec/deployments/0/spec/template/spec/containers/1/image", "value":"icr.io/cpopen/guardian-dm-operator@sha256:36df2a2cacd66f5cf8c01297728cb59dabc013d3c8d0b4eae3d8e1770f3839ec"}]'
 
-ISF_CSV=$(oc get csv -n $ISF_NS | grep "isf-operator.v2.7.2" | awk '{print $1}')
-if [[ -z ${ISF_CSV} ]]; then
-    echo "Cannot find the isf-operator.v2.7.2"
-    exit 1
-fi
-echo "Saving original to isf-operator.v2.7.2-original.yaml"
-oc get csv -n $ISF_NS ${ISF_CSV} -o yaml > isf-operator.v2.7.2-original.yaml
-echo "Updating SDS csv ${ISF_CSV}"
-oc patch csv -n $ISF_NS $ISF_CSV  --type='json' -p='[{"op":"replace", "path":"/spec/install/spec/deployments/0/spec/template/spec/containers/0/image", "value":"cp.icr.io/cp/isf-sds/isf-application-operator@sha256:845b8b7cd012363027fdcc537ac478773754ea0c0cead5e6ac4cb8e42f44b650"}]'

--- a/backup-restore/uninstall/uninstall-backup-restore.sh
+++ b/backup-restore/uninstall/uninstall-backup-restore.sh
@@ -91,6 +91,7 @@ oc -n "${ISF_NS}" get csv
 
 oc -n "$NAMESPACE" label dataprotectionagent --all uninstalling=true --overwrite
 oc -n "$NAMESPACE" label dataprotectionserver --all uninstalling=true --overwrite
+oc -n "$ISF_NS" label fusionserviceinstances ibm-backup-restore-service-instance ibm-backup-restore-agent-service-instance uninstalling=true --overwrite
 CONNECTION=$(oc -n "$NAMESPACE" get cm guardian-configmap -o custom-columns="CONN:data.connectionName" --no-headers)
 if [ -n "$CONNECTION" ]
   then


### PR DESCRIPTION
Label FSIs also when uninstalling B&R

Signed-off-by: Ajay Lunawat <100528036+ajaylun@users.noreply.github.com>