### PR TITLE
fix mmhealth status

### DIFF
--- a/upgrade-prechecks/preupgrade-healthcheck.sh
+++ b/upgrade-prechecks/preupgrade-healthcheck.sh
@@ -334,16 +334,16 @@ function verify_mmhealth_summary() {
 	while IFS= read -r line
 	do
 		comp=$(echo $line|awk '{print $1}')
-		failed=$(echo $line|awk '{print $3}')
-		degraded=$(echo $line|awk '{print $4}')
-		if [ ${failed} -ne 0 ]; then
-			print error "${CHECK_FAIL} ${failed} failed $comp found."
-			unhealthy=1
-		fi
-		if [ ${degraded} -ne 0 ]; then
+                failed=$(echo $line|awk '{print $3}')
+                degraded=$(echo $line|awk '{print $4}')
+                if [ "$failed" = "0" ]; then
+                        print error "${CHECK_FAIL} ${failed} failed $comp found."
+                        unhealthy=1
+                fi
+                if [ "${degraded}" = "0" ]; then
                         print error "${CHECK_FAIL} ${degraded} degraded $comp found."
-			unhealthy=1
-		fi
+                        unhealthy=1
+                fi
 	done <<< $(cat "${TEMP_MMHEALTH_FILE}")
 	if [ $unhealthy  -eq 0 ]; then
 		print info "${CHECK_PASS} All of IBM Storage Scale components are healthy."


### PR DESCRIPTION
Fixed error from mmhealth status

Before fix 

```
INFO: Verify IBM Storage Scale health
Defaulted container "gpfs" out of: gpfs, logs, mmbuildgpl (init), config (init)
NODE 6 0 0 5 1
NODE 0 0
./preupgrade-healthcheck.sh: line 343: [: 0: integer expression expected
./preupgrade-healthcheck.sh: line 347: [[: 0: syntax error: invalid arithmetic operator (error token is "")
GPFS 6 0 0 5 1
GPFS 0 0
./preupgrade-healthcheck.sh: line 343: [: 0: integer expression expected
./preupgrade-healthcheck.sh: line 347: [[: 0: syntax error: invalid arithmetic operator (error token is "")
NETWORK 6 0 0 6 0
NETWORK 0 0
./preupgrade-healthcheck.sh: line 343: [: 0: integer expression expected
./preupgrade-healthcheck.sh: line 347: [[: 0: syntax error: invalid arithmetic operator (error token is "")
FILESYSTEM 1 0 0 1 0
FILESYSTEM 0 0
./preupgrade-healthcheck.sh: line 343: [: 0: integer expression expected
./preupgrade-healthcheck.sh: line 347: [[: 0: syntax error: invalid arithmetic operator (error token is "")
DISK 12 0 0 12 0
DISK 0 0
./preupgrade-healthcheck.sh: line 343: [: 0: integer expression expected
./preupgrade-healthcheck.sh: line 347: [[: 0: syntax error: invalid arithmetic operator (error token is "")
FILESYSMGR 1 0 0 1 0
FILESYSMGR 0 0
./preupgrade-healthcheck.sh: line 343: [: 0: integer expression expected
./preupgrade-healthcheck.sh: line 347: [[: 0: syntax error: invalid arithmetic operator (error token is "")
GUI 2 0 0 2 0
GUI 0 0
./preupgrade-healthcheck.sh: line 343: [: 0: integer expression expected
./preupgrade-healthcheck.sh: line 347: [[: 0: syntax error: invalid arithmetic operator (error token is "")
NATIVE_RAID 6 0 0 6 0
NATIVE_RAID 0 0
./preupgrade-healthcheck.sh: line 343: [: 0: integer expression expected
./preupgrade-healthcheck.sh: line 347: [[: 0: syntax error: invalid arithmetic operator (error token is "")
PERFMON 6 0 0 6 0
PERFMON 0 0
./preupgrade-healthcheck.sh: line 343: [: 0: integer expression expected
./preupgrade-healthcheck.sh: line 347: [[: 0: syntax error: invalid arithmetic operator (error token is "")
THRESHOLD 6 0 0 6 0
THRESHOLD 0 0
./preupgrade-healthcheck.sh: line 343: [: 0: integer expression expected
./preupgrade-healthcheck.sh: line 347: [[: 0: syntax error: invalid arithmetic operator (error token is "")
INFO:   ✅ All of IBM Storage Scale components are healthy.

```


After fix

```
======================================================================================

INFO: Verify IBM Storage Scale health
Defaulted container "gpfs" out of: gpfs, logs, mmbuildgpl (init), config (init)
INFO:   ✅ All of IBM Storage Scale components are healthy.

======================================================================================
```