### PR TITLE
fix vm false positive

### DIFF
--- a/upgrade-prechecks/preupgrade-healthcheck.sh
+++ b/upgrade-prechecks/preupgrade-healthcheck.sh
@@ -674,11 +674,10 @@ function isAuthCorrect () {
 #clusters-scale-414        scale-414-7eec1c0e-n9gmj        2d15h   Running   True
 function get_virtual_machines () {
   vms=$(oc get virtualmachine -A 2>&1 >> /dev/null)
-  if [[ "${vms}" == "No resources found" ]]; then
+  if [[ $? -ne 0 ]] || [[ "${vms}" == "No resources found" ]];then
     print info "${CHECK_PASS} There are no virtual machines on this cluster, so there is no need to continue this check."
     return 0
   fi
-
 	nonMigratableVM=0
 	#vms=$(oc get virtualmachine -A|awk '{print $1 $2}')
 	#echo $vm
@@ -773,7 +772,7 @@ function verify_nodes_hw(){
       #check only configured nodes, not discovered one
       configuredNode=$(oc get computemonitoring -n ${FUSIONNS} $monitoringCRD -o json | jq .status.nodes[].ocpNodeName )
       if [[ "${configuredNode}" == null ]]; then
-        print error "$monitoringCRD is not part of OCP yet."
+        print info "${CHECK_UNKNOW} $monitoringCRD is not part of OCP yet."
       else
         nodeHwStatus=$(oc get computemonitoring -n ${FUSIONNS} $monitoringCRD -o json | jq .status.nodes[].nodeMonStatus.state)
         if ! [ "$nodeHwStatus" = "\"Succeeded\"" ]; then

--- a/upgrade-prechecks/preupgrade-healthcheck.sh
+++ b/upgrade-prechecks/preupgrade-healthcheck.sh
@@ -918,7 +918,7 @@ function verify_pid_limit(){
         pidvalue=$(oc debug node/$line -- chroot /host grep podPidsLimit /etc/kubernetes/kubelet.conf 2>/dev/null |awk '{ print $2}'|tr -d ,)
         if [ "$((pidvalue))" -lt 12228 ]; then
             flag=1
-            print error "PID LIMIT for node $line is less than 12228"
+            print error "${CHECK_FAIL} PID LIMIT for node $line is less than 12228"
         fi
     done < ${TEMP_MMHEALTH_FILE}
     if [ $flag -eq 0 ]; then


### PR DESCRIPTION
Script was reporting VMs as error even when VMs are not present. Fixed that in this PR

```
======================================================================================
Started healthcheck for IBM Storage Fusion HCI cluster at 2024-06-12 +0000 01:09:28 PM
======================================================================================

======================================================================================
			****** API access ******
======================================================================================

INFO: Verify Red Hat OpenShift API access.
INFO:   ✅ Red Hat OpenShift API is accessible.

======================================================================================
			****** Registry access ******
======================================================================================

Temporary namespace openshift-debug-gt2dn is created for debugging node...
Starting pod/control-1-ru2rackemydomaincom-debug-dsgcp ...
To use host binaries, run `chroot /host`

Removing debug pod ...
Temporary namespace openshift-debug-gt2dn was removed.
INFO:   ✅ quay.io is accessible.

======================================================================================

Temporary namespace openshift-debug-2x5rs is created for debugging node...
Starting pod/control-1-ru2rackemydomaincom-debug-8jf8p ...
To use host binaries, run `chroot /host`

Removing debug pod ...
Temporary namespace openshift-debug-2x5rs was removed.
INFO:   ✅ cp.icr.io is accessible.

======================================================================================

Temporary namespace openshift-debug-fjn9c is created for debugging node...
Starting pod/control-1-ru2rackemydomaincom-debug-g2r5n ...
To use host binaries, run `chroot /host`

Removing debug pod ...
Temporary namespace openshift-debug-fjn9c was removed.
INFO:   ✅ icr.io is accessible.

======================================================================================
			****** Registry authentication and authorisation ******
======================================================================================

Temporary namespace openshift-debug-hs6vm is created for debugging node...
Starting pod/control-1-ru2rackemydomaincom-debug-9x9wq ...
To use host binaries, run `chroot /host`

Removing debug pod ...
Temporary namespace openshift-debug-hs6vm was removed.
error: non-zero exit code from debug container
ERROR:   ❌ unable to pull image from IBM registry.

======================================================================================

Temporary namespace openshift-debug-dnkhw is created for debugging node...
Starting pod/control-1-ru2rackemydomaincom-debug-rnfm8 ...
To use host binaries, run `chroot /host`
Writing manifest to image destination

Removing debug pod ...
Temporary namespace openshift-debug-dnkhw was removed.
INFO:   ✅ successfully able to pull image from OpenShift quay.io.

======================================================================================
			****** Cluster operators ******
======================================================================================

INFO: Verify Red Hat OpenShift cluster operators health.
ERROR:   ❌  Cluster operator authentication is not healthy or/and ready.
ERROR:   ❌ authentication 4.15.12 False False True 3h52m WellKnownAvailable: The well-known endpoint is not yet available: failed to GET kube-apiserver oauth endpoint https://172.25.0.174:6443/.well-known/oauth-authorization-server: dial tcp 172.25.0.174:6443: i/o timeout
ERROR:   ❌  Cluster operator etcd is not healthy or/and ready.
ERROR:   ❌ etcd 4.15.12 True False True 7d5h EtcdEndpointsDegraded: EtcdEndpointsController can't evaluate whether quorum is safe: etcd cluster has quorum of 2 and 2 healthy members which is not fault tolerant: [{Member:ID:2106900712412626836 name:"control-2-ru2.racke.mydomain.com" peerURLs:"https://172.25.0.174:2380" clientURLs:"https://172.25.0.174:2379" Healthy:false Took: Error:create client failure: failed to make etcd client for endpoints [https://172.25.0.174:2379]: context deadline exceeded} {Member:ID:2833635042040623142 name:"control-1-ru2.racke.mydomain.com" peerURLs:"https://172.25.0.75:2380" clientURLs:"https://172.25.0.75:2379" Healthy:true Took:992.156µs Error:<nil>} {Member:ID:9382472388201929775 name:"control-3-ru2.racke.mydomain.com" peerURLs:"https://172.25.0.25:2380" clientURLs:"https://172.25.0.25:2379" Healthy:true Took:753.447µs Error:<nil>}]...

======================================================================================
			****** Nodes ******
======================================================================================

INFO: Verify Red Hat OpenShift nodes status.
INFO:   ✅ All Red Hat OpenShift nodes are Ready.

======================================================================================
			****** Machine configuration pools ******
======================================================================================

INFO: Verify machine config pools are updated.

======================================================================================

INFO:   ✅ All machine configuration pools are upto date.

======================================================================================
			****** Catalog sources ******
======================================================================================

INFO: Verify catalog sources health in cluster.
INFO:   ✅ All catalog sources are ready.

======================================================================================
			****** Fusion software ******
======================================================================================

INFO: Verify IBM Storage Fusion health.

======================================================================================
			****** Backup & Restore ******
======================================================================================

INFO: Verify IBM Storage Fusion Data protection health.
INFO:   ⏳ ibm-backup-restore project does not exist. It is possible that service is not installed or failed at very early stage.

======================================================================================
			****** Legacy SPP ******
======================================================================================

INFO: Verify IBM Storage Fusion legacy SPP health.
INFO:   ⏳ ibm-spectrum-protect-plus-ns project does not exist. It is possible that service is not installed or failed at very early stage.

======================================================================================
			****** Data Classification ******
======================================================================================

INFO: Verify Data classification service health.
INFO:   ⏳ ibm-data-cataloging project does not exist. It is possible that service is not installed or failed at very early stage.

======================================================================================
			****** Scale cluster ******
======================================================================================

INFO:   ⏳ ibm-spectrum-scale-operator project does not exist. It is possible that service is not installed or failed at very early stage.

======================================================================================
			****** VMs migration ******
======================================================================================

INFO:   ✅ There are no virtual machines on this cluster, so there is no need to continue this check.

======================================================================================
			****** Pods with imagepullbackoff across cluster ******
======================================================================================

INFO: Verify unhealthy pods across cluster.
ERROR:   ❌ Below pods in this cluster are unhealthy.
ibm-spectrum-fusion-ns                             fusionmanager-controller-6f4564d988-r9bbp                         0/1     ImagePullBackOff         0               3h43m
ibm-spectrum-fusion-ns                             isf-cns-operator-controller-manager-6ff796c54d-xn8cs              1/2     ImagePullBackOff         0               4h3m
ibm-spectrum-fusion-ns                             isf-storage-service-dep-74f76fc7b8-f84qw                          0/1     ImagePullBackOff         0               4h2m
ibm-spectrum-fusion-ns                             logcollector-5f78b76698-p4rlf                                     0/1     Pending                  0               14d
ibm-spectrum-fusion-ns                             logcollector-5f78b76698-pvgwg                                     0/1     Pending                  0               14d
openshift-operator-lifecycle-manager               collect-profiles-28636590-624mb                                   0/1     Error                    0               40m
openshift-operator-lifecycle-manager               collect-profiles-28636590-cnmcd                                   0/1     Error                    0               39m
openshift-operator-lifecycle-manager               collect-profiles-28636605-9kcqp                                   0/1     Error                    0               23m
openshift-operator-lifecycle-manager               collect-profiles-28636605-cdg4n                                   0/1     Error                    0               20m
openshift-operator-lifecycle-manager               collect-profiles-28636605-d4wn7                                   0/1     Error                    0               17m
openshift-operator-lifecycle-manager               collect-profiles-28636605-kdn68                                   0/1     Error                    0               24m
openshift-operator-lifecycle-manager               collect-profiles-28636605-zdrgk                                   0/1     Error                    0               22m
openshift-operator-lifecycle-manager               collect-profiles-28636605-zlnrg                                   0/1     Error                    0               25m
openshift-storage-client                           storageclient-abf16dbc3c286256-status-reporter-28636625-87s4h     0/1     ContainerStatusUnknown   2 (3m11s ago)   4m55s
openshift-storage                                  ceph-object-controller-detect-version-rl6nv                       0/1     Terminating              0               3s
openshift-storage                                  noobaa-default-backing-store-noobaa-pod-f59be3d3                  0/1     Pending                  0               46m
openshift-storage                                  ocs-metrics-exporter-7f55b59d97-m2fdc                             0/1     ImagePullBackOff         0               47m
openshift-storage                                  rook-ceph-rgw-ocs-storagecluster-cephobjectstore-a-54b597f5rrw8   1/2     CrashLoopBackOff         10 (83s ago)    47m

======================================================================================
			****** Nodes hardware status ******
======================================================================================

INFO: Verify node hardware status
ERROR:   ❌ "compute-1-ru3.racke.mydomain.com" hardware is not healthy
ERROR:   ❌ "compute-1-ru4.racke.mydomain.com" hardware is not healthy
INFO:   ⏳ monitoring-compute-1-ru5 is not part of OCP yet.
INFO:   ⏳ monitoring-compute-1-ru6 is not part of OCP yet.
INFO:   ⏳ monitoring-compute-1-ru7 is not part of OCP yet.
INFO:   ⏳ monitoring-compute-2-ru5 is not part of OCP yet.
INFO:   ⏳ monitoring-compute-2-ru6 is not part of OCP yet.
INFO:   ⏳ monitoring-compute-2-ru7 is not part of OCP yet.
INFO:   ⏳ monitoring-compute-3-ru3 is not part of OCP yet.
INFO:   ⏳ monitoring-compute-3-ru4 is not part of OCP yet.
INFO:   ⏳ monitoring-compute-3-ru5 is not part of OCP yet.
INFO:   ⏳ monitoring-compute-3-ru6 is not part of OCP yet.
INFO:   ⏳ monitoring-compute-3-ru7 is not part of OCP yet.

======================================================================================
			****** Fusion nodes maintenance ******
======================================================================================

INFO: Verify if any node is under fusion maintenance
INFO:   ✅ No node is under fusion maintenance.

======================================================================================
			****** Network checks ******
======================================================================================

INFO: Verify DNS on nodes
Temporary namespace openshift-debug-r796d is created for debugging node...
Starting pod/compute-1-ru3rackemydomaincom-debug-c9tz5 ...
To use host binaries, run `chroot /host`

Removing debug pod ...
Temporary namespace openshift-debug-r796d was removed.
INFO:   ✅ DNS is configured correctly on compute-1-ru3.racke.mydomain.com.
Temporary namespace openshift-debug-6vmbb is created for debugging node...
Starting pod/compute-1-ru4rackemydomaincom-debug-drs65 ...
To use host binaries, run `chroot /host`

Removing debug pod ...
Temporary namespace openshift-debug-6vmbb was removed.
INFO:   ✅ DNS is configured correctly on compute-1-ru4.racke.mydomain.com.
Temporary namespace openshift-debug-vn78x is created for debugging node...
Starting pod/compute-2-ru3rackemydomaincom-debug-f9drk ...
To use host binaries, run `chroot /host`

Removing debug pod ...
Temporary namespace openshift-debug-vn78x was removed.
INFO:   ✅ DNS is configured correctly on compute-2-ru3.racke.mydomain.com.
Temporary namespace openshift-debug-wfpsl is created for debugging node...
Starting pod/compute-2-ru4rackemydomaincom-debug-72zvf ...
To use host binaries, run `chroot /host`

Removing debug pod ...
Temporary namespace openshift-debug-wfpsl was removed.
INFO:   ✅ DNS is configured correctly on compute-2-ru4.racke.mydomain.com.
Temporary namespace openshift-debug-xx68g is created for debugging node...
Starting pod/control-1-ru2rackemydomaincom-debug-52mbt ...
To use host binaries, run `chroot /host`

Removing debug pod ...
Temporary namespace openshift-debug-xx68g was removed.
INFO:   ✅ DNS is configured correctly on control-1-ru2.racke.mydomain.com.
Temporary namespace openshift-debug-pbwv6 is created for debugging node...
Starting pod/control-2-ru2rackemydomaincom-debug-l57lh ...
To use host binaries, run `chroot /host`

Removing debug pod ...
Temporary namespace openshift-debug-pbwv6 was removed.
INFO:   ✅ DNS is configured correctly on control-2-ru2.racke.mydomain.com.
Temporary namespace openshift-debug-wdzth is created for debugging node...
Starting pod/control-3-ru2rackemydomaincom-debug-bff9w ...
To use host binaries, run `chroot /host`

Removing debug pod ...
Temporary namespace openshift-debug-wdzth was removed.
INFO:   ✅ DNS is configured correctly on control-3-ru2.racke.mydomain.com.

======================================================================================

INFO: Verify Link
INFO:   ✅ Link racke-links is healthy.
INFO:   ✅ Link rackf-links is healthy.
INFO:   ✅ Link rackg-links is healthy.

======================================================================================

INFO: Verify switch
INFO:   ✅ Switch hspeed1-racke is healthy.
INFO:   ✅ Switch hspeed1-rackf is healthy.
INFO:   ✅ Switch hspeed1-rackg is healthy.
INFO:   ✅ Switch hspeed2-racke is healthy.
INFO:   ✅ Switch hspeed2-rackf is healthy.
INFO:   ✅ Switch hspeed2-rackg is healthy.
INFO:   ✅ Switch mgmt1-racke is healthy.
INFO:   ✅ Switch mgmt1-rackf is healthy.
INFO:   ✅ Switch mgmt1-rackg is healthy.
INFO:   ✅ Switch mgmt2-racke is healthy.
INFO:   ✅ Switch mgmt2-rackf is healthy.
INFO:   ✅ Switch mgmt2-rackg is healthy.

======================================================================================

INFO: Verify vlan
INFO:   ✅ vlan "3201" is heathy.
INFO:   ✅ vlan "4091" is heathy.
INFO:   ✅ vlan "1" is heathy.
INFO:   ✅ vlan "851" is heathy.

======================================================================================
			****** Verify PID limit ******
======================================================================================

INFO: Verify PID Limit
ERROR:   ❌ PID LIMIT for node compute-1-ru3.racke.mydomain.com is less than 12228
ERROR:   ❌ PID LIMIT for node compute-1-ru4.racke.mydomain.com is less than 12228
ERROR:   ❌ PID LIMIT for node compute-2-ru3.racke.mydomain.com is less than 12228
ERROR:   ❌ PID LIMIT for node compute-2-ru4.racke.mydomain.com is less than 12228
ERROR:   ❌ PID LIMIT for node control-1-ru2.racke.mydomain.com is less than 12228
ERROR:   ❌ PID LIMIT for node control-2-ru2.racke.mydomain.com is less than 12228
ERROR:   ❌ PID LIMIT for node control-3-ru2.racke.mydomain.com is less than 12228

======================================================================================
			****** Verify Presence of CSI Configmap ******
======================================================================================

INFO: Verify presence of CSI configmap if it is a 2.6.1 MetroDR setup before going for 2.7.1 upgrade
INFO: Skipping CSI configmap verification as it is not a metroDR 2.6.1 setup

========================================================================================
Healthcheck for IBM Storage Fusion HCI cluster completed at 2024-06-12 +0000 01:10:31 PM
========================================================================================

```