### PR TITLE
add healthchecks

### DIFF
--- a/upgrade-prechecks/preupgrade-healthcheck.sh
+++ b/upgrade-prechecks/preupgrade-healthcheck.sh
@@ -1184,7 +1184,7 @@ elif [[ $# -eq 1 && "$1" == "postcheck" ]]; then
         print_footer
 elif [[ $# -eq 1 && "$1" == "healthcheck" ]]; then
         print_header
-#	preupgrade_checks
+        preupgrade_checks
 	print_section "CRDs count"
 	get_crd_count
 	print_section "NTP servers from nodes"


### PR DESCRIPTION
**UT:** 
**GDP**
```
./pre.sh healthcheck
======================================================================================
Started healthcheck for IBM Storage Fusion HCI cluster at 2024-07-22 -0400 08:50:16 AM
======================================================================================

======================================================================================
			****** API access ******
======================================================================================

INFO: Verify Red Hat OpenShift API access.
INFO:   ✅ Red Hat OpenShift API is accessible.

======================================================================================
			****** Registry access ******
======================================================================================

Warning: would violate PodSecurity "restricted:v1.24": host namespaces (hostNetwork=true, hostPID=true), privileged (container "container-00" must not set securityContext.privileged=true), allowPrivilegeEscalation != false (container "container-00" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (container "container-00" must set securityContext.capabilities.drop=["ALL"]), restricted volume types (volume "host" uses restricted volume type "hostPath"), runAsNonRoot != true (pod or container "container-00" must set securityContext.runAsNonRoot=true), runAsUser=0 (container "container-00" must not set runAsUser=0), seccompProfile (pod or container "container-00" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")
Starting pod/control-1-ru2isf-rackartpraleighibmcom-debug ...
To use host binaries, run `chroot /host`

Removing debug pod ...
INFO:   ✅ quay.io is accessible.

======================================================================================

Warning: would violate PodSecurity "restricted:v1.24": host namespaces (hostNetwork=true, hostPID=true), privileged (container "container-00" must not set securityContext.privileged=true), allowPrivilegeEscalation != false (container "container-00" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (container "container-00" must set securityContext.capabilities.drop=["ALL"]), restricted volume types (volume "host" uses restricted volume type "hostPath"), runAsNonRoot != true (pod or container "container-00" must set securityContext.runAsNonRoot=true), runAsUser=0 (container "container-00" must not set runAsUser=0), seccompProfile (pod or container "container-00" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")
Starting pod/control-1-ru2isf-rackartpraleighibmcom-debug ...
To use host binaries, run `chroot /host`

Removing debug pod ...
INFO:   ✅ cp.icr.io is accessible.

======================================================================================

Warning: would violate PodSecurity "restricted:v1.24": host namespaces (hostNetwork=true, hostPID=true), privileged (container "container-00" must not set securityContext.privileged=true), allowPrivilegeEscalation != false (container "container-00" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (container "container-00" must set securityContext.capabilities.drop=["ALL"]), restricted volume types (volume "host" uses restricted volume type "hostPath"), runAsNonRoot != true (pod or container "container-00" must set securityContext.runAsNonRoot=true), runAsUser=0 (container "container-00" must not set runAsUser=0), seccompProfile (pod or container "container-00" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")
Starting pod/control-1-ru2isf-rackartpraleighibmcom-debug ...
To use host binaries, run `chroot /host`

Removing debug pod ...
INFO:   ✅ icr.io is accessible.

======================================================================================
			****** Registry authentication and authorisation ******
======================================================================================

Warning: would violate PodSecurity "restricted:v1.24": host namespaces (hostNetwork=true, hostPID=true), privileged (container "container-00" must not set securityContext.privileged=true), allowPrivilegeEscalation != false (container "container-00" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (container "container-00" must set securityContext.capabilities.drop=["ALL"]), restricted volume types (volume "host" uses restricted volume type "hostPath"), runAsNonRoot != true (pod or container "container-00" must set securityContext.runAsNonRoot=true), runAsUser=0 (container "container-00" must not set runAsUser=0), seccompProfile (pod or container "container-00" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")
Starting pod/control-1-ru2isf-rackartpraleighibmcom-debug ...
To use host binaries, run `chroot /host`
Writing manifest to image destination

Removing debug pod ...
INFO:   ✅ successfully able to pull ISF images.

======================================================================================

Warning: would violate PodSecurity "restricted:v1.24": host namespaces (hostNetwork=true, hostPID=true), privileged (container "container-00" must not set securityContext.privileged=true), allowPrivilegeEscalation != false (container "container-00" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (container "container-00" must set securityContext.capabilities.drop=["ALL"]), restricted volume types (volume "host" uses restricted volume type "hostPath"), runAsNonRoot != true (pod or container "container-00" must set securityContext.runAsNonRoot=true), runAsUser=0 (container "container-00" must not set runAsUser=0), seccompProfile (pod or container "container-00" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")
Starting pod/control-1-ru2isf-rackartpraleighibmcom-debug ...
To use host binaries, run `chroot /host`
Writing manifest to image destination

Removing debug pod ...
INFO:   ✅ successfully able to pull image from OpenShift quay.io.

======================================================================================
			****** Cluster operators ******
======================================================================================

INFO: Verify Red Hat OpenShift cluster operators health.
INFO:   ✅ All Red Hat OpenShift cluster operators are healthy.

======================================================================================
			****** Nodes ******
======================================================================================

INFO: Verify Red Hat OpenShift nodes status.
INFO:   ✅ All Red Hat OpenShift nodes are Ready.

======================================================================================
			****** Machine configuration pools ******
======================================================================================

INFO: Verify machine config pools are updated.

======================================================================================

INFO:   ✅ All machine configuration pools are upto date.

======================================================================================
			****** Catalog sources ******
======================================================================================

INFO: Verify catalog sources health in cluster.
INFO:   ✅ All catalog sources are ready.

======================================================================================
			****** Fusion software ******
======================================================================================

INFO: Verify IBM Storage Fusion health.

======================================================================================
			****** Backup & Restore ******
======================================================================================

INFO: Verify IBM Storage Fusion Data protection health.
INFO:   ✅ All operators for data protection are healthy.

======================================================================================

INFO:   ✅ All pods for data protection are healthy.

======================================================================================

INFO:   ✅ All PVCs for data protection are bound.

======================================================================================
			****** Legacy SPP ******
======================================================================================

INFO: Verify IBM Storage Fusion legacy SPP health.
INFO:   ⏳ ibm-spectrum-protect-plus-ns project does not exist. It is possible that service is not installed or failed at very early stage.

======================================================================================
			****** Data Classification ******
======================================================================================

INFO: Verify Data classification service health.
INFO:   ✅ All operators for DCS are healthy.

======================================================================================

INFO:   ✅ All pods for DCS  are healthy.

======================================================================================

INFO:   ✅ All PVCs for DCS are bound.

======================================================================================
			****** Scale cluster ******
======================================================================================

INFO: Verify IBM Storage Scale operator pod status.
INFO:   ✅ IBM Storage Scale operator is healthy.

======================================================================================

INFO: Verify IBM Storage Scale daemon pods status.
INFO:   ✅ All of IBM Storage Scale daemon pods are healthy.

======================================================================================

INFO: Verify IBM Storage Scale dns pods status.
INFO:   ✅ All IBM Storage Scale dns pods are healthy.

======================================================================================

INFO: Verify IBM Storage Scale csi pods status.
INFO:   ✅ All IBM Storage Scale CSI pods are healthy.

======================================================================================

INFO: Verify IBM Storage Scale health
Defaulted container "gpfs" out of: gpfs, logs, mmbuildgpl (init), config (init)
./pre.sh: line 369: [: 0: integer expression expected
./pre.sh: line 373: [: 0: integer expression expected
./pre.sh: line 369: [: 0: integer expression expected
./pre.sh: line 373: [: 0: integer expression expected
./pre.sh: line 369: [: 0: integer expression expected
./pre.sh: line 373: [: 0: integer expression expected
./pre.sh: line 369: [: 0: integer expression expected
./pre.sh: line 373: [: 0: integer expression expected
./pre.sh: line 369: [: 0: integer expression expected
./pre.sh: line 373: [: 0: integer expression expected
./pre.sh: line 369: [: 0: integer expression expected
./pre.sh: line 373: [: 0: integer expression expected
./pre.sh: line 369: [: 0: integer expression expected
./pre.sh: line 373: [: 0: integer expression expected
./pre.sh: line 369: [: 0: integer expression expected
./pre.sh: line 373: [: 0: integer expression expected
./pre.sh: line 369: [: 0: integer expression expected
./pre.sh: line 373: [: 0: integer expression expected
./pre.sh: line 369: [: 0: integer expression expected
./pre.sh: line 373: [: 0: integer expression expected
INFO:   ✅ All of IBM Storage Scale components are healthy.

======================================================================================
			****** VMs migration ******
======================================================================================

INFO:   ✅ There are no virtual machines on this cluster, so there is no need to continue this check.

======================================================================================
			****** Pods with imagepullbackoff across cluster ******
======================================================================================

INFO: Verify unhealthy pods across cluster.
ERROR:   ❌ Below pods in this cluster are unhealthy.
auto-cpu-mem-io-workload-ns                        stress-compute-1-ru23.isf-racka.rtp.raleigh.ibm.com                          0/1     ImagePullBackOff    0                  2m21s
cpd-instance                                       zen-svc-inst-status-cron-job-28694200-nv2zx                                  0/1     CrashLoopBackOff    5 (2m1s ago)       11m
ibm-spectrum-fusion-ns                             ibm-spectrum-scale-sample-test-pod                                           0/1     ContainerCreating   0                  7d4h
mariadb2                                           mariadb2-699f9d5b7d-686sq                                                    0/1     ErrImagePull        0                  179m
openshift-storage                                  noobaa-operator-6477fc5c49-c9vg2                                             1/2     CrashLoopBackOff    1174 (2m40s ago)   6d5h

======================================================================================
			****** Nodes hardware status ******
======================================================================================

INFO: Verify node hardware status
INFO:   ✅ All configured nodes hardware is healthy.

======================================================================================
			****** Fusion nodes maintenance ******
======================================================================================

INFO: Verify if any node is under fusion maintenance
INFO:   ✅ No node is under fusion maintenance.

======================================================================================
			****** Network checks ******
======================================================================================

INFO: Verify DNS on nodes
Warning: would violate PodSecurity "restricted:v1.24": host namespaces (hostNetwork=true, hostPID=true), privileged (container "container-00" must not set securityContext.privileged=true), allowPrivilegeEscalation != false (container "container-00" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (container "container-00" must set securityContext.capabilities.drop=["ALL"]), restricted volume types (volume "host" uses restricted volume type "hostPath"), runAsNonRoot != true (pod or container "container-00" must set securityContext.runAsNonRoot=true), runAsUser=0 (container "container-00" must not set runAsUser=0), seccompProfile (pod or container "container-00" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")
Starting pod/compute-1-ru23isf-rackartpraleighibmcom-debug ...
To use host binaries, run `chroot /host`

Removing debug pod ...
INFO:   ✅ DNS is configured correctly on compute-1-ru23.isf-racka.rtp.raleigh.ibm.com.
Warning: would violate PodSecurity "restricted:v1.24": host namespaces (hostNetwork=true, hostPID=true), privileged (container "container-00" must not set securityContext.privileged=true), allowPrivilegeEscalation != false (container "container-00" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (container "container-00" must set securityContext.capabilities.drop=["ALL"]), restricted volume types (volume "host" uses restricted volume type "hostPath"), runAsNonRoot != true (pod or container "container-00" must set securityContext.runAsNonRoot=true), runAsUser=0 (container "container-00" must not set runAsUser=0), seccompProfile (pod or container "container-00" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")
Starting pod/compute-1-ru24isf-rackartpraleighibmcom-debug ...
To use host binaries, run `chroot /host`

Removing debug pod ...
INFO:   ✅ DNS is configured correctly on compute-1-ru24.isf-racka.rtp.raleigh.ibm.com.
Warning: would violate PodSecurity "restricted:v1.24": host namespaces (hostNetwork=true, hostPID=true), privileged (container "container-00" must not set securityContext.privileged=true), allowPrivilegeEscalation != false (container "container-00" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (container "container-00" must set securityContext.capabilities.drop=["ALL"]), restricted volume types (volume "host" uses restricted volume type "hostPath"), runAsNonRoot != true (pod or container "container-00" must set securityContext.runAsNonRoot=true), runAsUser=0 (container "container-00" must not set runAsUser=0), seccompProfile (pod or container "container-00" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")
Starting pod/compute-1-ru25isf-rackartpraleighibmcom-debug ...
To use host binaries, run `chroot /host`

Removing debug pod ...
INFO:   ✅ DNS is configured correctly on compute-1-ru25.isf-racka.rtp.raleigh.ibm.com.
Warning: would violate PodSecurity "restricted:v1.24": host namespaces (hostNetwork=true, hostPID=true), privileged (container "container-00" must not set securityContext.privileged=true), allowPrivilegeEscalation != false (container "container-00" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (container "container-00" must set securityContext.capabilities.drop=["ALL"]), restricted volume types (volume "host" uses restricted volume type "hostPath"), runAsNonRoot != true (pod or container "container-00" must set securityContext.runAsNonRoot=true), runAsUser=0 (container "container-00" must not set runAsUser=0), seccompProfile (pod or container "container-00" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")
Starting pod/compute-1-ru5isf-rackartpraleighibmcom-debug ...
To use host binaries, run `chroot /host`

Removing debug pod ...
INFO:   ✅ DNS is configured correctly on compute-1-ru5.isf-racka.rtp.raleigh.ibm.com.
Warning: would violate PodSecurity "restricted:v1.24": host namespaces (hostNetwork=true, hostPID=true), privileged (container "container-00" must not set securityContext.privileged=true), allowPrivilegeEscalation != false (container "container-00" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (container "container-00" must set securityContext.capabilities.drop=["ALL"]), restricted volume types (volume "host" uses restricted volume type "hostPath"), runAsNonRoot != true (pod or container "container-00" must set securityContext.runAsNonRoot=true), runAsUser=0 (container "container-00" must not set runAsUser=0), seccompProfile (pod or container "container-00" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")
Starting pod/compute-1-ru6isf-rackartpraleighibmcom-debug ...
To use host binaries, run `chroot /host`

Removing debug pod ...
INFO:   ✅ DNS is configured correctly on compute-1-ru6.isf-racka.rtp.raleigh.ibm.com.
Warning: would violate PodSecurity "restricted:v1.24": host namespaces (hostNetwork=true, hostPID=true), privileged (container "container-00" must not set securityContext.privileged=true), allowPrivilegeEscalation != false (container "container-00" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (container "container-00" must set securityContext.capabilities.drop=["ALL"]), restricted volume types (volume "host" uses restricted volume type "hostPath"), runAsNonRoot != true (pod or container "container-00" must set securityContext.runAsNonRoot=true), runAsUser=0 (container "container-00" must not set runAsUser=0), seccompProfile (pod or container "container-00" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")
Starting pod/compute-1-ru7isf-rackartpraleighibmcom-debug ...
To use host binaries, run `chroot /host`

Removing debug pod ...
INFO:   ✅ DNS is configured correctly on compute-1-ru7.isf-racka.rtp.raleigh.ibm.com.
Warning: would violate PodSecurity "restricted:v1.24": host namespaces (hostNetwork=true, hostPID=true), privileged (container "container-00" must not set securityContext.privileged=true), allowPrivilegeEscalation != false (container "container-00" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (container "container-00" must set securityContext.capabilities.drop=["ALL"]), restricted volume types (volume "host" uses restricted volume type "hostPath"), runAsNonRoot != true (pod or container "container-00" must set securityContext.runAsNonRoot=true), runAsUser=0 (container "container-00" must not set runAsUser=0), seccompProfile (pod or container "container-00" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")
Starting pod/control-1-ru2isf-rackartpraleighibmcom-debug ...
To use host binaries, run `chroot /host`

Removing debug pod ...
INFO:   ✅ DNS is configured correctly on control-1-ru2.isf-racka.rtp.raleigh.ibm.com.
Warning: would violate PodSecurity "restricted:v1.24": host namespaces (hostNetwork=true, hostPID=true), privileged (container "container-00" must not set securityContext.privileged=true), allowPrivilegeEscalation != false (container "container-00" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (container "container-00" must set securityContext.capabilities.drop=["ALL"]), restricted volume types (volume "host" uses restricted volume type "hostPath"), runAsNonRoot != true (pod or container "container-00" must set securityContext.runAsNonRoot=true), runAsUser=0 (container "container-00" must not set runAsUser=0), seccompProfile (pod or container "container-00" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")
Starting pod/control-1-ru3isf-rackartpraleighibmcom-debug ...
To use host binaries, run `chroot /host`

Removing debug pod ...
INFO:   ✅ DNS is configured correctly on control-1-ru3.isf-racka.rtp.raleigh.ibm.com.
Warning: would violate PodSecurity "restricted:v1.24": host namespaces (hostNetwork=true, hostPID=true), privileged (container "container-00" must not set securityContext.privileged=true), allowPrivilegeEscalation != false (container "container-00" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (container "container-00" must set securityContext.capabilities.drop=["ALL"]), restricted volume types (volume "host" uses restricted volume type "hostPath"), runAsNonRoot != true (pod or container "container-00" must set securityContext.runAsNonRoot=true), runAsUser=0 (container "container-00" must not set runAsUser=0), seccompProfile (pod or container "container-00" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")
Starting pod/control-1-ru4isf-rackartpraleighibmcom-debug ...
To use host binaries, run `chroot /host`

Removing debug pod ...
INFO:   ✅ DNS is configured correctly on control-1-ru4.isf-racka.rtp.raleigh.ibm.com.

======================================================================================

INFO: Verify Link
INFO:   ✅ Link racka-links is healthy.

======================================================================================

INFO: Verify switch
INFO:   ✅ Switch hspeed1-racka is healthy.
INFO:   ✅ Switch hspeed2-racka is healthy.
INFO:   ✅ Switch mgmt1-racka is healthy.
INFO:   ✅ Switch mgmt2-racka is healthy.

======================================================================================

INFO: Verify vlan
INFO:   ✅ vlan "3201" is heathy.
INFO:   ✅ vlan "4091" is heathy.
INFO:   ✅ vlan "1" is heathy.
INFO:   ✅ vlan "920" is heathy.

======================================================================================
			****** Verify PID limit ******
======================================================================================

INFO: Verify PID Limit
INFO:   ✅ PID limit on all nodes are okay.

======================================================================================
			****** Verify Presence of CSI Configmap ******
======================================================================================

INFO: Verify presence of CSI configmap if it is a 2.6.1 MetroDR setup before going for 2.7.1 upgrade
INFO: Skipping CSI configmap verification as it is not a metroDR 2.6.1 setup

======================================================================================
			****** CRDs count ******
======================================================================================

INFO: Get total CRDs count in system
INFO:   ✅ CRD count 385 is moderate.

======================================================================================
			****** NTP servers from nodes ******
======================================================================================


======================================================================================
			****** PDBs with zero disruption allowed ******
======================================================================================


======================================================================================
			****** ETCD health ******
======================================================================================

+------------------+---------+---------------------------------------------+---------------------------+---------------------------+------------+
|        ID        | STATUS  |                    NAME                     |        PEER ADDRS         |       CLIENT ADDRS        | IS LEARNER |
+------------------+---------+---------------------------------------------+---------------------------+---------------------------+------------+
| 48faf7a3860c3cd2 | started | control-1-ru3.isf-racka.rtp.raleigh.ibm.com | https://9.42.107.146:2380 | https://9.42.107.146:2379 |      false |
| 50dbb60bd1d53d04 | started | control-1-ru2.isf-racka.rtp.raleigh.ibm.com | https://9.42.107.145:2380 | https://9.42.107.145:2379 |      false |
| c1af62c995c9f94a | started | control-1-ru4.isf-racka.rtp.raleigh.ibm.com | https://9.42.107.147:2380 | https://9.42.107.147:2379 |      false |
+------------------+---------+---------------------------------------------+---------------------------+---------------------------+------------+
https://9.42.107.145:2379 is healthy: successfully committed proposal: took = 12.558494ms
https://9.42.107.146:2379 is healthy: successfully committed proposal: took = 12.358387ms
https://9.42.107.147:2379 is healthy: successfully committed proposal: took = 12.696594ms
+---------------------------+--------+-------------+-------+
|         ENDPOINT          | HEALTH |    TOOK     | ERROR |
+---------------------------+--------+-------------+-------+
| https://9.42.107.146:2379 |   true | 13.983389ms |       |
| https://9.42.107.147:2379 |   true | 17.715471ms |       |
| https://9.42.107.145:2379 |   true | 17.655208ms |       |
+---------------------------+--------+-------------+-------+
+---------------------------+------------------+---------+---------+-----------+------------+-----------+------------+--------------------+--------+
|         ENDPOINT          |        ID        | VERSION | DB SIZE | IS LEADER | IS LEARNER | RAFT TERM | RAFT INDEX | RAFT APPLIED INDEX | ERRORS |
+---------------------------+------------------+---------+---------+-----------+------------+-----------+------------+--------------------+--------+
| https://9.42.107.146:2379 | 48faf7a3860c3cd2 |  3.5.13 |  390 MB |     false |      false |        21 |   57651218 |           57651218 |        |
| https://9.42.107.145:2379 | 50dbb60bd1d53d04 |  3.5.13 |  441 MB |     false |      false |        21 |   57651218 |           57651218 |        |
| https://9.42.107.147:2379 | c1af62c995c9f94a |  3.5.13 |  381 MB |      true |      false |        21 |   57651218 |           57651218 |        |
+---------------------------+------------------+---------+---------+-----------+------------+-----------+------------+--------------------+--------+

======================================================================================
			****** Log collector PVC usage ******
======================================================================================

INFO:  log collector pvc has sufficient spac, however deleting old collections is always recommended

======================================================================================
			****** Frequent pod restarts ******
======================================================================================

NAMESPACE                                          NAME                                                                         READY   STATUS              RESTARTS           AGE
cpd-instance                                       bamdev-cais-84f89449d4-slk4k                                                 2/2     Running             2 (4d1h ago)       6d20h
cpd-instance                                       ibm-mcs-placement-777c795dd6-fhwsf                                           1/1     Running             1 (3d ago)         3d
cpd-instance                                       zen-database-core-5f5bbf6b44-fbj6p                                           1/1     Running             1 (21h ago)        2d23h
cpd-instance                                       zen-svc-inst-status-cron-job-28694200-nv2zx                                  0/1     CrashLoopBackOff    5 (2m32s ago)      11m
ibm-backup-restore                                 backuppolicy-deployment-668454d985-j7mnk                                     1/1     Running             1 (9d ago)         9d
ibm-data-cataloging                                c-isd-db2u-0                                                                 0/1     Running             2 (3d11h ago)      3d20h
ibm-data-cataloging                                c-isd-db2u-1                                                                 1/1     Running             1 (3d11h ago)      3d20h
ibm-spectrum-fusion-ns                             eventmanager-6dcf44bd6f-7hgv8                                                1/1     Running             8 (22h ago)        9d
ibm-spectrum-fusion-ns                             eventmanager-6dcf44bd6f-t4cck                                                1/1     Running             6 (15h ago)        9d
ibm-spectrum-scale-dns                             coredns-2k6p4                                                                1/1     Running             1                  10d
ibm-spectrum-scale-dns                             coredns-2ssz8                                                                1/1     Running             1                  10d
ibm-spectrum-scale-dns                             coredns-6pl5w                                                                1/1     Running             1                  10d
ibm-spectrum-scale-dns                             coredns-k2jjs                                                                1/1     Running             1                  10d
ibm-spectrum-scale-dns                             coredns-lwxgk                                                                1/1     Running             1                  10d
ibm-spectrum-scale-dns                             coredns-m68cb                                                                1/1     Running             1                  10d
ibm-spectrum-scale-dns                             coredns-p8h7s                                                                1/1     Running             1                  10d
ibm-spectrum-scale-dns                             coredns-r6q4h                                                                1/1     Running             1                  10d
ibm-spectrum-scale-operator                        ibm-spectrum-scale-controller-manager-7c68cddffb-6h9dg                       1/1     Running             1 (3d21h ago)      9d
ibm-spectrum-scale                                 ibm-spectrum-scale-gui-0                                                     4/4     Running             2 (9d ago)         9d
ibm-spectrum-scale                                 ibm-spectrum-scale-gui-1                                                     4/4     Running             2 (9d ago)         9d
instana-agent                                      instana-agent-bsg24                                                          1/1     Running             9 (4d21h ago)      9d
instana-agent                                      instana-agent-dsj54                                                          1/1     Running             7 (4d17h ago)      9d
instana-agent                                      instana-agent-ts4lr                                                          1/1     Running             5 (5d3h ago)       9d
openshift-cluster-node-tuning-operator             tuned-2bjrj                                                                  1/1     Running             2                  15d
openshift-cluster-node-tuning-operator             tuned-6gv2s                                                                  1/1     Running             2                  15d
openshift-cluster-node-tuning-operator             tuned-77hbg                                                                  1/1     Running             2                  15d
openshift-cluster-node-tuning-operator             tuned-8kgjt                                                                  1/1     Running             2                  15d
openshift-cluster-node-tuning-operator             tuned-96zzs                                                                  1/1     Running             2                  15d
openshift-cluster-node-tuning-operator             tuned-bgm54                                                                  1/1     Running             2                  15d
openshift-cluster-node-tuning-operator             tuned-btkcn                                                                  1/1     Running             2                  15d
openshift-cluster-node-tuning-operator             tuned-v6c28                                                                  1/1     Running             2                  15d
openshift-cluster-node-tuning-operator             tuned-vd4cw                                                                  1/1     Running             2                  15d
openshift-dns                                      dns-default-2ts89                                                            2/2     Running             4                  15d
openshift-dns                                      dns-default-46td4                                                            2/2     Running             4                  15d
openshift-dns                                      dns-default-6bcg9                                                            2/2     Running             4                  15d
openshift-dns                                      dns-default-c94h8                                                            2/2     Running             4                  15d
openshift-dns                                      dns-default-h2dcn                                                            2/2     Running             4                  15d
openshift-dns                                      dns-default-kzrfm                                                            2/2     Running             4                  15d
openshift-dns                                      dns-default-n8nzn                                                            2/2     Running             4                  15d
openshift-dns                                      dns-default-ntsr6                                                            2/2     Running             4                  15d
openshift-dns                                      dns-default-w7hpq                                                            2/2     Running             4                  15d
openshift-dns                                      node-resolver-46vmr                                                          1/1     Running             2                  15d
openshift-dns                                      node-resolver-5dxdv                                                          1/1     Running             2                  15d
openshift-dns                                      node-resolver-6pf5j                                                          1/1     Running             2                  15d
openshift-dns                                      node-resolver-86r7h                                                          1/1     Running             2                  15d
openshift-dns                                      node-resolver-k958f                                                          1/1     Running             2                  15d
openshift-dns                                      node-resolver-l6hbx                                                          1/1     Running             2                  15d
openshift-dns                                      node-resolver-lv8w7                                                          1/1     Running             2                  15d
openshift-dns                                      node-resolver-ssqcq                                                          1/1     Running             2                  15d
openshift-dns                                      node-resolver-wsrlz                                                          1/1     Running             2                  15d
openshift-etcd                                     etcd-control-1-ru2.isf-racka.rtp.raleigh.ibm.com                             4/4     Running             4                  15d
openshift-etcd                                     etcd-control-1-ru3.isf-racka.rtp.raleigh.ibm.com                             4/4     Running             4                  15d
openshift-etcd                                     etcd-control-1-ru4.isf-racka.rtp.raleigh.ibm.com                             4/4     Running             4                  15d
openshift-image-registry                           node-ca-4sczm                                                                1/1     Running             2                  15d
openshift-image-registry                           node-ca-5xs5b                                                                1/1     Running             2                  15d
openshift-image-registry                           node-ca-68vrp                                                                1/1     Running             2                  15d
openshift-image-registry                           node-ca-7bmw5                                                                1/1     Running             2                  15d
openshift-image-registry                           node-ca-89g2q                                                                1/1     Running             2                  15d
openshift-image-registry                           node-ca-bhsnl                                                                1/1     Running             2                  15d
openshift-image-registry                           node-ca-gh59v                                                                1/1     Running             2                  15d
openshift-image-registry                           node-ca-gr5fd                                                                1/1     Running             2                  15d
openshift-image-registry                           node-ca-njqvj                                                                1/1     Running             2                  15d
openshift-ingress-canary                           ingress-canary-crm4w                                                         1/1     Running             2                  15d
openshift-ingress-canary                           ingress-canary-fs7fl                                                         1/1     Running             2                  15d
openshift-ingress-canary                           ingress-canary-h7mrx                                                         1/1     Running             2                  15d
openshift-ingress-canary                           ingress-canary-jxqbc                                                         1/1     Running             2                  15d
openshift-ingress-canary                           ingress-canary-psm7t                                                         1/1     Running             2                  15d
openshift-ingress-canary                           ingress-canary-qczq2                                                         1/1     Running             2                  15d
openshift-kni-infra                                coredns-compute-1-ru23.isf-racka.rtp.raleigh.ibm.com                         2/2     Running             2                  15d
openshift-kni-infra                                coredns-compute-1-ru24.isf-racka.rtp.raleigh.ibm.com                         2/2     Running             2                  15d
openshift-kni-infra                                coredns-compute-1-ru25.isf-racka.rtp.raleigh.ibm.com                         2/2     Running             2                  15d
openshift-kni-infra                                coredns-compute-1-ru5.isf-racka.rtp.raleigh.ibm.com                          2/2     Running             2                  15d
openshift-kni-infra                                coredns-compute-1-ru6.isf-racka.rtp.raleigh.ibm.com                          2/2     Running             2                  15d
openshift-kni-infra                                coredns-compute-1-ru7.isf-racka.rtp.raleigh.ibm.com                          2/2     Running             2                  15d
openshift-kni-infra                                coredns-control-1-ru2.isf-racka.rtp.raleigh.ibm.com                          2/2     Running             2                  15d
openshift-kni-infra                                coredns-control-1-ru3.isf-racka.rtp.raleigh.ibm.com                          2/2     Running             2                  15d
openshift-kni-infra                                coredns-control-1-ru4.isf-racka.rtp.raleigh.ibm.com                          2/2     Running             2                  15d
openshift-kni-infra                                haproxy-control-1-ru2.isf-racka.rtp.raleigh.ibm.com                          2/2     Running             2                  15d
openshift-kni-infra                                haproxy-control-1-ru3.isf-racka.rtp.raleigh.ibm.com                          2/2     Running             2                  15d
openshift-kni-infra                                haproxy-control-1-ru4.isf-racka.rtp.raleigh.ibm.com                          2/2     Running             2                  15d
openshift-kni-infra                                keepalived-compute-1-ru23.isf-racka.rtp.raleigh.ibm.com                      2/2     Running             2                  15d
openshift-kni-infra                                keepalived-compute-1-ru24.isf-racka.rtp.raleigh.ibm.com                      2/2     Running             2                  15d
openshift-kni-infra                                keepalived-compute-1-ru25.isf-racka.rtp.raleigh.ibm.com                      2/2     Running             2                  15d
openshift-kni-infra                                keepalived-compute-1-ru5.isf-racka.rtp.raleigh.ibm.com                       2/2     Running             3                  15d
openshift-kni-infra                                keepalived-compute-1-ru6.isf-racka.rtp.raleigh.ibm.com                       2/2     Running             2                  15d
openshift-kni-infra                                keepalived-compute-1-ru7.isf-racka.rtp.raleigh.ibm.com                       2/2     Running             2                  15d
openshift-kni-infra                                keepalived-control-1-ru2.isf-racka.rtp.raleigh.ibm.com                       2/2     Running             2                  15d
openshift-kni-infra                                keepalived-control-1-ru3.isf-racka.rtp.raleigh.ibm.com                       2/2     Running             2                  15d
openshift-kni-infra                                keepalived-control-1-ru4.isf-racka.rtp.raleigh.ibm.com                       2/2     Running             2                  15d
openshift-kube-controller-manager                  kube-controller-manager-control-1-ru2.isf-racka.rtp.raleigh.ibm.com          4/4     Running             4                  15d
openshift-kube-controller-manager                  kube-controller-manager-control-1-ru3.isf-racka.rtp.raleigh.ibm.com          4/4     Running             4                  15d
openshift-kube-controller-manager                  kube-controller-manager-control-1-ru4.isf-racka.rtp.raleigh.ibm.com          4/4     Running             4                  15d
openshift-kube-scheduler                           openshift-kube-scheduler-control-1-ru2.isf-racka.rtp.raleigh.ibm.com         3/3     Running             3                  15d
openshift-kube-scheduler                           openshift-kube-scheduler-control-1-ru3.isf-racka.rtp.raleigh.ibm.com         3/3     Running             3                  15d
openshift-kube-scheduler                           openshift-kube-scheduler-control-1-ru4.isf-racka.rtp.raleigh.ibm.com         3/3     Running             3                  15d
openshift-machine-config-operator                  kube-rbac-proxy-crio-compute-1-ru23.isf-racka.rtp.raleigh.ibm.com            1/1     Running             1                  15d
openshift-machine-config-operator                  kube-rbac-proxy-crio-compute-1-ru24.isf-racka.rtp.raleigh.ibm.com            1/1     Running             1                  15d
openshift-machine-config-operator                  kube-rbac-proxy-crio-compute-1-ru25.isf-racka.rtp.raleigh.ibm.com            1/1     Running             1                  15d
openshift-machine-config-operator                  kube-rbac-proxy-crio-compute-1-ru5.isf-racka.rtp.raleigh.ibm.com             1/1     Running             1                  15d
openshift-machine-config-operator                  kube-rbac-proxy-crio-compute-1-ru6.isf-racka.rtp.raleigh.ibm.com             1/1     Running             1                  15d
openshift-machine-config-operator                  kube-rbac-proxy-crio-compute-1-ru7.isf-racka.rtp.raleigh.ibm.com             1/1     Running             1                  15d
openshift-machine-config-operator                  kube-rbac-proxy-crio-control-1-ru2.isf-racka.rtp.raleigh.ibm.com             1/1     Running             1                  15d
openshift-machine-config-operator                  kube-rbac-proxy-crio-control-1-ru3.isf-racka.rtp.raleigh.ibm.com             1/1     Running             1                  15d
openshift-machine-config-operator                  kube-rbac-proxy-crio-control-1-ru4.isf-racka.rtp.raleigh.ibm.com             1/1     Running             1                  15d
openshift-machine-config-operator                  machine-config-daemon-6dwr9                                                  2/2     Running             4                  15d
openshift-machine-config-operator                  machine-config-daemon-7kfs4                                                  2/2     Running             4                  15d
openshift-machine-config-operator                  machine-config-daemon-7wkbt                                                  2/2     Running             4                  15d
openshift-machine-config-operator                  machine-config-daemon-9jlvv                                                  2/2     Running             4                  15d
openshift-machine-config-operator                  machine-config-daemon-kv4mf                                                  2/2     Running             4                  15d
openshift-machine-config-operator                  machine-config-daemon-nkvm2                                                  2/2     Running             4                  15d
openshift-machine-config-operator                  machine-config-daemon-nmrpq                                                  2/2     Running             4                  15d
openshift-machine-config-operator                  machine-config-daemon-q4nx8                                                  2/2     Running             4                  15d
openshift-machine-config-operator                  machine-config-daemon-wm6z8                                                  2/2     Running             4                  15d
openshift-machine-config-operator                  machine-config-server-gfbh2                                                  1/1     Running             2                  15d
openshift-machine-config-operator                  machine-config-server-sxqh6                                                  1/1     Running             2                  15d
openshift-machine-config-operator                  machine-config-server-v4kfb                                                  1/1     Running             2                  15d
openshift-monitoring                               node-exporter-7x7th                                                          2/2     Running             4                  15d
openshift-monitoring                               node-exporter-cpl4k                                                          2/2     Running             4                  15d
openshift-monitoring                               node-exporter-ht6ls                                                          2/2     Running             4                  15d
openshift-monitoring                               node-exporter-lz2g7                                                          2/2     Running             4                  15d
openshift-monitoring                               node-exporter-nrk7v                                                          2/2     Running             4                  15d
openshift-monitoring                               node-exporter-v9jvd                                                          2/2     Running             4                  15d
openshift-monitoring                               node-exporter-wpb9r                                                          2/2     Running             4                  15d
openshift-monitoring                               node-exporter-xsp9t                                                          2/2     Running             4                  15d
openshift-monitoring                               node-exporter-z89jh                                                          2/2     Running             4                  15d
openshift-multus                                   multus-4dr69                                                                 1/1     Running             4                  15d
openshift-multus                                   multus-6dqzb                                                                 1/1     Running             4                  15d
openshift-multus                                   multus-6n42s                                                                 1/1     Running             4                  15d
openshift-multus                                   multus-7m9l8                                                                 1/1     Running             4                  15d
openshift-multus                                   multus-89khw                                                                 1/1     Running             4                  15d
openshift-multus                                   multus-additional-cni-plugins-2wjfm                                          1/1     Running             2                  15d
openshift-multus                                   multus-additional-cni-plugins-4hqbm                                          1/1     Running             2                  15d
openshift-multus                                   multus-additional-cni-plugins-6wdcp                                          1/1     Running             2                  15d
openshift-multus                                   multus-additional-cni-plugins-9bbm6                                          1/1     Running             2                  15d
openshift-multus                                   multus-additional-cni-plugins-dpsq5                                          1/1     Running             2                  15d
openshift-multus                                   multus-additional-cni-plugins-qhg4d                                          1/1     Running             2                  15d
openshift-multus                                   multus-additional-cni-plugins-vmnbr                                          1/1     Running             2                  15d
openshift-multus                                   multus-additional-cni-plugins-wmgxk                                          1/1     Running             2                  15d
openshift-multus                                   multus-additional-cni-plugins-zf6fk                                          1/1     Running             2                  15d
openshift-multus                                   multus-q5mjt                                                                 1/1     Running             4                  15d
openshift-multus                                   multus-r6rcj                                                                 1/1     Running             4                  15d
openshift-multus                                   multus-r89fp                                                                 1/1     Running             4                  15d
openshift-multus                                   multus-tmt9g                                                                 1/1     Running             4                  15d
openshift-multus                                   network-metrics-daemon-2ntmp                                                 2/2     Running             4                  15d
openshift-multus                                   network-metrics-daemon-5bhgn                                                 2/2     Running             4                  15d
openshift-multus                                   network-metrics-daemon-7h5zk                                                 2/2     Running             4                  15d
openshift-multus                                   network-metrics-daemon-7pkcj                                                 2/2     Running             4                  15d
openshift-multus                                   network-metrics-daemon-hjgs4                                                 2/2     Running             4                  15d
openshift-multus                                   network-metrics-daemon-n4882                                                 2/2     Running             4                  15d
openshift-multus                                   network-metrics-daemon-rdbp6                                                 2/2     Running             4                  15d
openshift-multus                                   network-metrics-daemon-tpvq2                                                 2/2     Running             5                  15d
openshift-multus                                   network-metrics-daemon-w8wxc                                                 2/2     Running             4                  15d
openshift-multus                                   whereabouts-reconciler-4pfqk                                                 1/1     Running             2                  15d
openshift-multus                                   whereabouts-reconciler-82xd4                                                 1/1     Running             2                  15d
openshift-multus                                   whereabouts-reconciler-84f9g                                                 1/1     Running             2                  15d
openshift-multus                                   whereabouts-reconciler-mrfrx                                                 1/1     Running             2                  15d
openshift-multus                                   whereabouts-reconciler-rkcvt                                                 1/1     Running             2                  15d
openshift-multus                                   whereabouts-reconciler-vjdlq                                                 1/1     Running             2                  15d
openshift-multus                                   whereabouts-reconciler-xv5n9                                                 1/1     Running             2                  15d
openshift-multus                                   whereabouts-reconciler-zh66p                                                 1/1     Running             2                  15d
openshift-multus                                   whereabouts-reconciler-zswgq                                                 1/1     Running             2                  15d
openshift-network-diagnostics                      network-check-target-92jcf                                                   1/1     Running             2                  15d
openshift-network-diagnostics                      network-check-target-chn68                                                   1/1     Running             2                  15d
openshift-network-diagnostics                      network-check-target-hx5bn                                                   1/1     Running             2                  15d
openshift-network-diagnostics                      network-check-target-j2f7n                                                   1/1     Running             2                  15d
openshift-network-diagnostics                      network-check-target-kg8wc                                                   1/1     Running             2                  15d
openshift-network-diagnostics                      network-check-target-lnlhq                                                   1/1     Running             2                  15d
openshift-network-diagnostics                      network-check-target-m4pvg                                                   1/1     Running             2                  15d
openshift-network-diagnostics                      network-check-target-q82rs                                                   1/1     Running             2                  15d
openshift-network-diagnostics                      network-check-target-rt95g                                                   1/1     Running             2                  15d
openshift-network-node-identity                    network-node-identity-mz7b7                                                  2/2     Running             5                  15d
openshift-network-node-identity                    network-node-identity-rbhcp                                                  2/2     Running             5                  15d
openshift-network-node-identity                    network-node-identity-vj5d4                                                  2/2     Running             4                  15d
openshift-ovn-kubernetes                           ovnkube-node-85gjl                                                           8/8     Running             16                 15d
openshift-ovn-kubernetes                           ovnkube-node-8dkcw                                                           8/8     Running             16                 15d
openshift-ovn-kubernetes                           ovnkube-node-9dq9s                                                           8/8     Running             16                 15d
openshift-ovn-kubernetes                           ovnkube-node-bxzlv                                                           8/8     Running             16                 15d
openshift-ovn-kubernetes                           ovnkube-node-c2wqb                                                           8/8     Running             16                 15d
openshift-ovn-kubernetes                           ovnkube-node-jf8xc                                                           8/8     Running             16                 15d
openshift-ovn-kubernetes                           ovnkube-node-jq72t                                                           8/8     Running             16                 15d
openshift-ovn-kubernetes                           ovnkube-node-khtlm                                                           8/8     Running             17                 15d
openshift-ovn-kubernetes                           ovnkube-node-q2cc7                                                           8/8     Running             16                 15d
openshift-storage                                  noobaa-operator-6477fc5c49-c9vg2                                             1/2     CrashLoopBackOff    1174 (3m12s ago)   6d5h
postgres                                           postgres-deployment-5f4b6c8f74-q8l78                                         1/1     Running             1 (17h ago)        17h
postgres2                                          postgres-deployment-5f4b6c8f74-dxbx5                                         1/1     Running             1 (175m ago)       176m
postgres3                                          postgres-deployment-5f4b6c8f74-drrdt                                         1/1     Running             1 (156m ago)       156m
postgres4                                          postgres-deployment-5f4b6c8f74-bmlln                                         1/1     Running             1 (123m ago)       124m
postgres5                                          postgres-deployment-5f4b6c8f74-qs824                                         1/1     Running             1 (122m ago)       122m

======================================================================================
			****** Critical events ******
======================================================================================

INFO:   ⏳ No critical events found

======================================================================================
			****** Critical alerts ******
======================================================================================

"NodeClockNotSynchronising"
"Clock at control-1-ru2.isf-racka.rtp.raleigh.ibm.com is not synchronising. Ensure NTP is configured on this host."

========================================================================================
Healthcheck for IBM Storage Fusion HCI cluster completed at 2024-07-22 -0400 08:51:22 AM
========================================================================================

```
**DF**

```
======================================================================================
Started healthcheck for IBM Storage Fusion HCI cluster at 2024-07-22 -0400 08:20:52 AM
======================================================================================

======================================================================================
			****** CRDs count ******
======================================================================================

INFO: Get total CRDs count in system
I0722 08:20:53.631123    1743 request.go:668] Waited for 1.174343735s due to client-side throttling, not priority and fairness, request: GET:https://api.rackm06.mydomain.com:6443/apis/cluster.x-k8s.io/v1beta1?timeout=32s
WARN:  CRD count 538 is high, perform housekeeping by removing operators that are not in use. If CRD count reaches 512, you'll experience throttling in system

======================================================================================
			****** NTP servers from nodes ******
======================================================================================


======================================================================================
			****** PDBs with zero disruption allowed ******
======================================================================================


======================================================================================
			****** ETCD health ******
======================================================================================

+------------------+---------+------------------------------------+--------------------------+--------------------------+------------+
|        ID        | STATUS  |                NAME                |        PEER ADDRS        |       CLIENT ADDRS       | IS LEARNER |
+------------------+---------+------------------------------------+--------------------------+--------------------------+------------+
|  9a276cda24b26a1 | started | control-1-ru2.rackm06.mydomain.com | https://172.17.6.25:2380 | https://172.17.6.25:2379 |      false |
| 3c9bfb292bb31b41 | started | control-1-ru3.rackm06.mydomain.com | https://172.17.6.26:2380 | https://172.17.6.26:2379 |      false |
| 7604db99d94dd4ae | started | control-1-ru4.rackm06.mydomain.com | https://172.17.6.27:2380 | https://172.17.6.27:2379 |      false |
+------------------+---------+------------------------------------+--------------------------+--------------------------+------------+
https://172.17.6.25:2379 is healthy: successfully committed proposal: took = 7.51141ms
https://172.17.6.27:2379 is healthy: successfully committed proposal: took = 10.388296ms
https://172.17.6.26:2379 is healthy: successfully committed proposal: took = 10.60361ms
+--------------------------+--------+-------------+-------+
|         ENDPOINT         | HEALTH |    TOOK     | ERROR |
+--------------------------+--------+-------------+-------+
| https://172.17.6.25:2379 |   true |  7.808717ms |       |
| https://172.17.6.26:2379 |   true | 10.767527ms |       |
| https://172.17.6.27:2379 |   true | 11.206701ms |       |
+--------------------------+--------+-------------+-------+
+--------------------------+------------------+---------+---------+-----------+------------+-----------+------------+--------------------+--------+
|         ENDPOINT         |        ID        | VERSION | DB SIZE | IS LEADER | IS LEARNER | RAFT TERM | RAFT INDEX | RAFT APPLIED INDEX | ERRORS |
+--------------------------+------------------+---------+---------+-----------+------------+-----------+------------+--------------------+--------+
| https://172.17.6.25:2379 |  9a276cda24b26a1 |  3.5.13 |  508 MB |     false |      false |        13 |   21844070 |           21844070 |        |
| https://172.17.6.26:2379 | 3c9bfb292bb31b41 |  3.5.13 |  514 MB |      true |      false |        13 |   21844070 |           21844070 |        |
| https://172.17.6.27:2379 | 7604db99d94dd4ae |  3.5.13 |  567 MB |     false |      false |        13 |   21844071 |           21844071 |        |
+--------------------------+------------------+---------+---------+-----------+------------+-----------+------------+--------------------+--------+

======================================================================================
			****** Log collector PVC usage ******
======================================================================================

INFO:  log collector pvc has sufficient spac, however deleting old collections is always recommended

======================================================================================
			****** Frequent pod restarts ******
======================================================================================

NAMESPACE                                          NAME                                                                READY   STATUS        RESTARTS        AGE
cpd-instance                                       bamdev-cais-66b5c44c95-7p4db                                        2/2     Running       2 (24h ago)     45h
cpd-instance                                       zen-watcher-6fd4bd4b69-v4v24                                        2/2     Running       2 (11h ago)     2d22h
ibm-licensing                                      ibm-licensing-operator-6b8d675c98-xs8ql                             1/1     Running       1 (2d22h ago)   2d22h
ibm-spectrum-fusion-ns                             eventmanager-5d4c75bc64-mqzqv                                       1/1     Running       4 (133m ago)    6d5h
ibm-spectrum-fusion-ns                             eventmanager-5d4c75bc64-xqpqp                                       1/1     Running       2 (16h ago)     6d5h
nvidia-gpu-operator                                nvidia-dcgm-exporter-ph6q2                                          1/1     Running       1 (5d21h ago)   5d21h
open-cluster-management                            multicluster-integrations-7469d96d58-k5jrj                          3/3     Running       1 (2d23h ago)   2d23h
open-cluster-management                            multicluster-operators-application-7ffb87999f-kw9ls                 3/3     Running       2 (2d23h ago)   2d23h
open-cluster-management                            multicluster-operators-channel-5b6bbb9c6b-9vnf6                     1/1     Running       1 (2d23h ago)   2d23h
open-cluster-management                            multicluster-operators-hub-subscription-7bc8fb8ccc-7wccw            1/1     Running       1 (2d23h ago)   2d23h
open-cluster-management                            search-postgres-cb59bf665-9zn55                                     1/1     Running       5 (178m ago)    2d23h
openshift-cluster-node-tuning-operator             tuned-6r6hn                                                         1/1     Running       1               6d20h
openshift-cluster-node-tuning-operator             tuned-jf998                                                         1/1     Running       1               6d20h
openshift-cluster-node-tuning-operator             tuned-qxp27                                                         1/1     Running       1               6d20h
openshift-cnv                                      ssp-operator-685fb74fb-hbt94                                        1/1     Running       1 (5d3h ago)    5d6h
openshift-dns                                      dns-default-kbkhr                                                   2/2     Running       2               6d19h
openshift-dns                                      dns-default-l2969                                                   2/2     Running       2               6d19h
openshift-dns                                      dns-default-vz5xl                                                   2/2     Running       2               6d19h
openshift-dns                                      node-resolver-65qxs                                                 1/1     Running       1               6d19h
openshift-dns                                      node-resolver-9tjcw                                                 1/1     Running       1               6d19h
openshift-dns                                      node-resolver-lsn5h                                                 1/1     Running       1               6d19h
openshift-etcd                                     etcd-control-1-ru2.rackm06.mydomain.com                             4/4     Running       4               6d20h
openshift-etcd                                     etcd-control-1-ru3.rackm06.mydomain.com                             4/4     Running       4               6d20h
openshift-etcd                                     etcd-control-1-ru4.rackm06.mydomain.com                             4/4     Running       4               6d20h
openshift-image-registry                           node-ca-g5vks                                                       1/1     Running       1               6d20h
openshift-image-registry                           node-ca-h4ghj                                                       1/1     Running       1               6d20h
openshift-image-registry                           node-ca-nh2dh                                                       1/1     Running       1               6d20h
openshift-ingress-canary                           ingress-canary-6fm8p                                                1/1     Running       1               6d20h
openshift-ingress-canary                           ingress-canary-94b5q                                                1/1     Running       1               6d20h
openshift-ingress-canary                           ingress-canary-krwrj                                                1/1     Running       1               6d20h
openshift-kni-infra                                coredns-control-1-ru2.rackm06.mydomain.com                          2/2     Running       2               6d19h
openshift-kni-infra                                coredns-control-1-ru3.rackm06.mydomain.com                          2/2     Running       2               6d19h
openshift-kni-infra                                coredns-control-1-ru4.rackm06.mydomain.com                          2/2     Running       2               6d19h
openshift-kni-infra                                haproxy-control-1-ru2.rackm06.mydomain.com                          2/2     Running       2               6d19h
openshift-kni-infra                                haproxy-control-1-ru3.rackm06.mydomain.com                          2/2     Running       2               6d19h
openshift-kni-infra                                haproxy-control-1-ru4.rackm06.mydomain.com                          2/2     Running       2               6d19h
openshift-kni-infra                                keepalived-control-1-ru2.rackm06.mydomain.com                       2/2     Running       2               6d19h
openshift-kni-infra                                keepalived-control-1-ru3.rackm06.mydomain.com                       2/2     Running       2               6d19h
openshift-kni-infra                                keepalived-control-1-ru4.rackm06.mydomain.com                       2/2     Running       2               6d19h
openshift-kube-controller-manager                  kube-controller-manager-control-1-ru2.rackm06.mydomain.com          4/4     Running       4               6d20h
openshift-kube-controller-manager                  kube-controller-manager-control-1-ru3.rackm06.mydomain.com          4/4     Running       5 (98m ago)     6d20h
openshift-kube-controller-manager                  kube-controller-manager-control-1-ru4.rackm06.mydomain.com          4/4     Running       4               6d20h
openshift-kube-scheduler                           openshift-kube-scheduler-control-1-ru2.rackm06.mydomain.com         3/3     Running       3               6d20h
openshift-kube-scheduler                           openshift-kube-scheduler-control-1-ru3.rackm06.mydomain.com         3/3     Running       3               6d20h
openshift-kube-scheduler                           openshift-kube-scheduler-control-1-ru4.rackm06.mydomain.com         3/3     Running       3               6d20h
openshift-machine-config-operator                  kube-rbac-proxy-crio-compute-1-ru10.rackm06.mydomain.com            1/1     Running       2 (6d17h ago)   6d17h
openshift-machine-config-operator                  kube-rbac-proxy-crio-compute-1-ru11.rackm06.mydomain.com            1/1     Running       2 (6d17h ago)   6d17h
openshift-machine-config-operator                  kube-rbac-proxy-crio-compute-1-ru25.rackm06.mydomain.com            1/1     Running       2 (6d17h ago)   6d17h
openshift-machine-config-operator                  kube-rbac-proxy-crio-compute-1-ru5.rackm06.mydomain.com             1/1     Running       2 (6d17h ago)   6d17h
openshift-machine-config-operator                  kube-rbac-proxy-crio-compute-1-ru6.rackm06.mydomain.com             1/1     Running       2 (6d17h ago)   6d17h
openshift-machine-config-operator                  kube-rbac-proxy-crio-compute-1-ru7.rackm06.mydomain.com             1/1     Running       2 (6d17h ago)   6d17h
openshift-machine-config-operator                  kube-rbac-proxy-crio-compute-1-ru8.rackm06.mydomain.com             1/1     Running       2 (6d17h ago)   6d17h
openshift-machine-config-operator                  kube-rbac-proxy-crio-compute-1-ru9.rackm06.mydomain.com             1/1     Running       2 (6d17h ago)   6d17h
openshift-machine-config-operator                  kube-rbac-proxy-crio-control-1-ru2.rackm06.mydomain.com             1/1     Running       1               6d19h
openshift-machine-config-operator                  kube-rbac-proxy-crio-control-1-ru3.rackm06.mydomain.com             1/1     Running       1               6d19h
openshift-machine-config-operator                  kube-rbac-proxy-crio-control-1-ru4.rackm06.mydomain.com             1/1     Running       1               6d19h
openshift-machine-config-operator                  machine-config-daemon-7vxv9                                         2/2     Running       2               6d19h
openshift-machine-config-operator                  machine-config-daemon-gzw62                                         2/2     Running       2               6d19h
openshift-machine-config-operator                  machine-config-daemon-tcgfg                                         2/2     Running       2               6d19h
openshift-machine-config-operator                  machine-config-server-cfmz5                                         1/1     Running       1               6d19h
openshift-machine-config-operator                  machine-config-server-hwq9p                                         1/1     Running       1               6d19h
openshift-machine-config-operator                  machine-config-server-m766h                                         1/1     Running       1               6d19h
openshift-monitoring                               node-exporter-kvkz2                                                 2/2     Running       2               6d20h
openshift-monitoring                               node-exporter-r59fc                                                 2/2     Running       2               6d20h
openshift-monitoring                               node-exporter-wrnc4                                                 2/2     Running       2               6d20h
openshift-multus                                   multus-9wsz5                                                        1/1     Running       2               6d19h
openshift-multus                                   multus-additional-cni-plugins-8zgjd                                 1/1     Running       1               6d19h
openshift-multus                                   multus-additional-cni-plugins-g6wkt                                 1/1     Running       1               6d19h
openshift-multus                                   multus-additional-cni-plugins-lv7pl                                 1/1     Running       1               6d19h
openshift-multus                                   multus-b6jcw                                                        1/1     Running       2               6d19h
openshift-multus                                   multus-dsjkc                                                        1/1     Running       2               6d19h
openshift-multus                                   network-metrics-daemon-dbv9k                                        2/2     Running       2               6d19h
openshift-multus                                   network-metrics-daemon-vtf8x                                        2/2     Running       2               6d19h
openshift-multus                                   network-metrics-daemon-wtz62                                        2/2     Running       2               6d19h
openshift-multus                                   whereabouts-reconciler-4gthz                                        1/1     Running       3 (6d17h ago)   6d17h
openshift-multus                                   whereabouts-reconciler-dxnn7                                        1/1     Running       2 (6d17h ago)   6d17h
openshift-multus                                   whereabouts-reconciler-g8g2p                                        1/1     Running       1               6d19h
openshift-multus                                   whereabouts-reconciler-g9tpx                                        1/1     Running       1               6d19h
openshift-multus                                   whereabouts-reconciler-gfm2g                                        1/1     Running       2 (6d17h ago)   6d17h
openshift-multus                                   whereabouts-reconciler-lhtgs                                        1/1     Running       2 (6d17h ago)   6d17h
openshift-multus                                   whereabouts-reconciler-n28w9                                        1/1     Running       2 (6d17h ago)   6d17h
openshift-multus                                   whereabouts-reconciler-pl9vq                                        1/1     Running       1               6d19h
openshift-multus                                   whereabouts-reconciler-rvtpv                                        1/1     Running       2 (6d17h ago)   6d17h
openshift-multus                                   whereabouts-reconciler-vzkcm                                        1/1     Running       3 (6d17h ago)   6d17h
openshift-multus                                   whereabouts-reconciler-zgc6l                                        1/1     Running       3 (6d17h ago)   6d17h
openshift-network-diagnostics                      network-check-target-rnmwz                                          1/1     Running       1               6d19h
openshift-network-diagnostics                      network-check-target-rv5f6                                          1/1     Running       1               6d19h
openshift-network-diagnostics                      network-check-target-xtblb                                          1/1     Running       1               6d19h
openshift-network-node-identity                    network-node-identity-4qh8k                                         2/2     Running       3               6d19h
openshift-network-node-identity                    network-node-identity-f7gqm                                         2/2     Running       3 (97m ago)     6d19h
openshift-network-node-identity                    network-node-identity-pc6fv                                         2/2     Running       2               6d19h
openshift-network-operator                         iptables-alerter-bkt9f                                              1/1     Running       1               6d19h
openshift-network-operator                         iptables-alerter-srnrl                                              1/1     Running       1               6d19h
openshift-network-operator                         iptables-alerter-x4j6d                                              1/1     Running       1               6d19h
openshift-ovn-kubernetes                           ovnkube-node-mw8gg                                                  8/8     Running       8               6d19h
openshift-ovn-kubernetes                           ovnkube-node-nm4g9                                                  8/8     Running       8               6d19h
openshift-ovn-kubernetes                           ovnkube-node-skg5j                                                  8/8     Running       8               6d19h
openshift-storage                                  csi-cephfsplugin-46fb9                                              2/2     Running       1 (6d5h ago)    6d5h
openshift-storage                                  csi-cephfsplugin-46vck                                              2/2     Running       1 (6d5h ago)    6d5h
openshift-storage                                  csi-cephfsplugin-4bxkd                                              2/2     Running       1 (6d5h ago)    6d5h
openshift-storage                                  csi-cephfsplugin-9skj8                                              2/2     Running       1 (6d5h ago)    6d5h
openshift-storage                                  csi-cephfsplugin-b7g7c                                              2/2     Running       1 (6d5h ago)    6d5h
openshift-storage                                  csi-cephfsplugin-cnmsb                                              2/2     Running       1 (6d5h ago)    6d5h
openshift-storage                                  csi-cephfsplugin-flxzk                                              2/2     Running       1 (6d5h ago)    6d5h
openshift-storage                                  csi-cephfsplugin-pj4b9                                              2/2     Running       1 (6d5h ago)    6d5h
openshift-storage                                  csi-cephfsplugin-provisioner-5b6cfc85c6-jmhbc                       5/5     Running       4 (6d5h ago)    6d5h
openshift-storage                                  csi-cephfsplugin-provisioner-5b6cfc85c6-s9lcg                       5/5     Running       4 (6d5h ago)    6d5h
openshift-storage                                  csi-cephfsplugin-rhb4v                                              2/2     Running       1 (6d5h ago)    6d5h
openshift-storage                                  csi-cephfsplugin-x4x9h                                              2/2     Running       1 (6d5h ago)    6d5h
openshift-storage                                  csi-cephfsplugin-z4czq                                              2/2     Running       1 (6d5h ago)    6d5h
openshift-storage                                  csi-rbdplugin-5t4dp                                                 3/3     Running       1 (6d5h ago)    6d5h
openshift-storage                                  csi-rbdplugin-66stt                                                 3/3     Running       2 (6d5h ago)    6d5h
openshift-storage                                  csi-rbdplugin-6zrrj                                                 3/3     Running       2 (6d5h ago)    6d5h
openshift-storage                                  csi-rbdplugin-7t4d7                                                 3/3     Running       2 (6d5h ago)    6d5h
openshift-storage                                  csi-rbdplugin-dcppq                                                 3/3     Running       2 (6d5h ago)    6d5h
openshift-storage                                  csi-rbdplugin-g9slg                                                 3/3     Running       2 (6d5h ago)    6d5h
openshift-storage                                  csi-rbdplugin-glz8n                                                 3/3     Running       1 (6d5h ago)    6d5h
openshift-storage                                  csi-rbdplugin-pdxx8                                                 3/3     Running       2 (6d5h ago)    6d5h
openshift-storage                                  csi-rbdplugin-provisioner-5764589f6c-pglxv                          6/6     Running       5 (6d5h ago)    6d5h
openshift-storage                                  csi-rbdplugin-r7566                                                 3/3     Running       2 (6d5h ago)    6d5h
openshift-storage                                  csi-rbdplugin-s45r9                                                 3/3     Running       2 (6d5h ago)    6d5h
openshift-storage                                  csi-rbdplugin-t84k7                                                 3/3     Running       2 (6d5h ago)    6d5h

======================================================================================
			****** Critical events ******
======================================================================================

INFO:   ⏳ No critical events found

======================================================================================
			****** Critical alerts ******
======================================================================================

"NodeClockNotSynchronising"
"Clock at control-1-ru2.rackm06.mydomain.com is not synchronising. Ensure NTP is configured on this host."
"PodDisruptionBudgetLimit"
"The pod disruption budget is below the minimum disruptions allowed level and is not satisfied. The number of current healthy pods is less than the desired healthy pods."

========================================================================================
Healthcheck for IBM Storage Fusion HCI cluster completed at 2024-07-22 -0400 08:21:21 AM
========================================================================================
[root@isfmgen10 upgrade-prechecks]# vi preupgrade-healthcheck.sh 
[root@isfmgen10 upgrade-prechecks]# ./preupgrade-healthcheck.sh healthcheck
======================================================================================
Started healthcheck for IBM Storage Fusion HCI cluster at 2024-07-22 -0400 08:24:51 AM
======================================================================================

======================================================================================
			****** API access ******
======================================================================================

INFO: Verify Red Hat OpenShift API access.
INFO:   ✅ Red Hat OpenShift API is accessible.

======================================================================================
			****** Registry access ******
======================================================================================

Starting pod/control-1-ru2rackm06mydomaincom-debug ...
To use host binaries, run `chroot /host`

Removing debug pod ...
INFO:   ✅ quay.io is accessible.

======================================================================================

Starting pod/control-1-ru2rackm06mydomaincom-debug ...
To use host binaries, run `chroot /host`

Removing debug pod ...
INFO:   ✅ cp.icr.io is accessible.

======================================================================================

Starting pod/control-1-ru2rackm06mydomaincom-debug ...
To use host binaries, run `chroot /host`

Removing debug pod ...
INFO:   ✅ icr.io is accessible.

======================================================================================
			****** Registry authentication and authorisation ******
======================================================================================

Starting pod/control-1-ru2rackm06mydomaincom-debug ...
To use host binaries, run `chroot /host`
Writing manifest to image destination

Removing debug pod ...
INFO:   ✅ successfully able to pull ISF images.

======================================================================================

Starting pod/control-1-ru2rackm06mydomaincom-debug ...
To use host binaries, run `chroot /host`

Removing debug pod ...
Writing manifest to image destination
INFO:   ✅ successfully able to pull image from OpenShift quay.io.

======================================================================================
			****** Cluster operators ******
======================================================================================

INFO: Verify Red Hat OpenShift cluster operators health.
INFO:   ✅ All Red Hat OpenShift cluster operators are healthy.

======================================================================================
			****** Nodes ******
======================================================================================

INFO: Verify Red Hat OpenShift nodes status.
INFO:   ✅ All Red Hat OpenShift nodes are Ready.

======================================================================================
			****** Machine configuration pools ******
======================================================================================

INFO: Verify machine config pools are updated.

======================================================================================

INFO:   ✅ All machine configuration pools are upto date.

======================================================================================
			****** Catalog sources ******
======================================================================================

INFO: Verify catalog sources health in cluster.
INFO:   ✅ All catalog sources are ready.

======================================================================================
			****** Fusion software ******
======================================================================================

INFO: Verify IBM Storage Fusion health.

======================================================================================
			****** Backup & Restore ******
======================================================================================

INFO: Verify IBM Storage Fusion Data protection health.
INFO:   ✅ All operators for data protection are healthy.

======================================================================================

INFO:   ✅ All pods for data protection are healthy.

======================================================================================

INFO:   ✅ All PVCs for data protection are bound.

======================================================================================
			****** Legacy SPP ******
======================================================================================

INFO: Verify IBM Storage Fusion legacy SPP health.
INFO:   ⏳ ibm-spectrum-protect-plus-ns project does not exist. It is possible that service is not installed or failed at very early stage.

======================================================================================
			****** Data Classification ******
======================================================================================

INFO: Verify Data classification service health.
INFO:   ⏳ ibm-data-cataloging project does not exist. It is possible that service is not installed or failed at very early stage.

======================================================================================
			****** Scale cluster ******
======================================================================================

INFO:   ⏳ ibm-spectrum-scale-operator project does not exist. It is possible that service is not installed or failed at very early stage.

======================================================================================
			****** VMs migration ******
======================================================================================

INFO:   ✅ All vms are migratable.

======================================================================================
			****** Pods with imagepullbackoff across cluster ******
======================================================================================

INFO: Verify unhealthy pods across cluster.
ERROR:   ❌ Below pods in this cluster are unhealthy.

======================================================================================
			****** Nodes hardware status ******
======================================================================================

INFO: Verify node hardware status
INFO:   ✅ All configured nodes hardware is healthy.

======================================================================================
			****** Fusion nodes maintenance ******
======================================================================================

INFO: Verify if any node is under fusion maintenance
INFO:   ✅ No node is under fusion maintenance.

======================================================================================
			****** Network checks ******
======================================================================================

INFO: Verify DNS on nodes
Starting pod/compute-1-ru10rackm06mydomaincom-debug ...
To use host binaries, run `chroot /host`

Removing debug pod ...
INFO:   ✅ DNS is configured correctly on compute-1-ru10.rackm06.mydomain.com.
Starting pod/compute-1-ru11rackm06mydomaincom-debug ...
To use host binaries, run `chroot /host`

Removing debug pod ...
INFO:   ✅ DNS is configured correctly on compute-1-ru11.rackm06.mydomain.com.
Starting pod/compute-1-ru25rackm06mydomaincom-debug ...
To use host binaries, run `chroot /host`

Removing debug pod ...
INFO:   ✅ DNS is configured correctly on compute-1-ru25.rackm06.mydomain.com.
Starting pod/compute-1-ru5rackm06mydomaincom-debug ...
To use host binaries, run `chroot /host`

Removing debug pod ...
INFO:   ✅ DNS is configured correctly on compute-1-ru5.rackm06.mydomain.com.
Starting pod/compute-1-ru6rackm06mydomaincom-debug ...
To use host binaries, run `chroot /host`

Removing debug pod ...
INFO:   ✅ DNS is configured correctly on compute-1-ru6.rackm06.mydomain.com.
Starting pod/compute-1-ru7rackm06mydomaincom-debug ...
To use host binaries, run `chroot /host`

Removing debug pod ...
INFO:   ✅ DNS is configured correctly on compute-1-ru7.rackm06.mydomain.com.
Starting pod/compute-1-ru8rackm06mydomaincom-debug ...
To use host binaries, run `chroot /host`

Removing debug pod ...
INFO:   ✅ DNS is configured correctly on compute-1-ru8.rackm06.mydomain.com.
Starting pod/compute-1-ru9rackm06mydomaincom-debug ...
To use host binaries, run `chroot /host`

Removing debug pod ...
INFO:   ✅ DNS is configured correctly on compute-1-ru9.rackm06.mydomain.com.
Starting pod/control-1-ru2rackm06mydomaincom-debug ...
To use host binaries, run `chroot /host`

Removing debug pod ...
INFO:   ✅ DNS is configured correctly on control-1-ru2.rackm06.mydomain.com.
Starting pod/control-1-ru3rackm06mydomaincom-debug ...
To use host binaries, run `chroot /host`

Removing debug pod ...
INFO:   ✅ DNS is configured correctly on control-1-ru3.rackm06.mydomain.com.
Starting pod/control-1-ru4rackm06mydomaincom-debug ...
To use host binaries, run `chroot /host`

Removing debug pod ...
INFO:   ✅ DNS is configured correctly on control-1-ru4.rackm06.mydomain.com.

======================================================================================

INFO: Verify Link
INFO:   ✅ Link rackm06-links is healthy.

======================================================================================

INFO: Verify switch
INFO:   ✅ Switch hspeed1-rackm06 is healthy.
INFO:   ✅ Switch hspeed2-rackm06 is healthy.
INFO:   ✅ Switch mgmt1-rackm06 is healthy.
INFO:   ✅ Switch mgmt2-rackm06 is healthy.

======================================================================================

INFO: Verify vlan
INFO:   ✅ vlan "3201" is heathy.
INFO:   ✅ vlan "4091" is heathy.
INFO:   ✅ vlan "1" is heathy.
INFO:   ✅ vlan "6" is heathy.

======================================================================================
			****** Verify PID limit ******
======================================================================================

INFO: Verify PID Limit
INFO:  No need to check pidslimit on system with ODF provider mode storage

======================================================================================
			****** Verify Presence of CSI Configmap ******
======================================================================================

INFO: Verify presence of CSI configmap if it is a 2.6.1 MetroDR setup before going for 2.7.1 upgrade
INFO: Skipping CSI configmap verification as it is not a metroDR 2.6.1 setup

======================================================================================
			****** CRDs count ******
======================================================================================

INFO: Get total CRDs count in system
WARN:  CRD count 538 is high, perform housekeeping by removing operators that are not in use. If CRD count reaches 512, you'll experience throttling in system

======================================================================================
			****** NTP servers from nodes ******
======================================================================================


======================================================================================
			****** PDBs with zero disruption allowed ******
======================================================================================


======================================================================================
			****** ETCD health ******
======================================================================================

+------------------+---------+------------------------------------+--------------------------+--------------------------+------------+
|        ID        | STATUS  |                NAME                |        PEER ADDRS        |       CLIENT ADDRS       | IS LEARNER |
+------------------+---------+------------------------------------+--------------------------+--------------------------+------------+
|  9a276cda24b26a1 | started | control-1-ru2.rackm06.mydomain.com | https://172.17.6.25:2380 | https://172.17.6.25:2379 |      false |
| 3c9bfb292bb31b41 | started | control-1-ru3.rackm06.mydomain.com | https://172.17.6.26:2380 | https://172.17.6.26:2379 |      false |
| 7604db99d94dd4ae | started | control-1-ru4.rackm06.mydomain.com | https://172.17.6.27:2380 | https://172.17.6.27:2379 |      false |
+------------------+---------+------------------------------------+--------------------------+--------------------------+------------+
https://172.17.6.25:2379 is healthy: successfully committed proposal: took = 6.570164ms
https://172.17.6.26:2379 is healthy: successfully committed proposal: took = 8.768557ms
https://172.17.6.27:2379 is healthy: successfully committed proposal: took = 9.058542ms
+--------------------------+--------+-------------+-------+
|         ENDPOINT         | HEALTH |    TOOK     | ERROR |
+--------------------------+--------+-------------+-------+
| https://172.17.6.25:2379 |   true |  8.158623ms |       |
| https://172.17.6.26:2379 |   true | 13.069846ms |       |
| https://172.17.6.27:2379 |   true | 14.886393ms |       |
+--------------------------+--------+-------------+-------+
+--------------------------+------------------+---------+---------+-----------+------------+-----------+------------+--------------------+--------+
|         ENDPOINT         |        ID        | VERSION | DB SIZE | IS LEADER | IS LEARNER | RAFT TERM | RAFT INDEX | RAFT APPLIED INDEX | ERRORS |
+--------------------------+------------------+---------+---------+-----------+------------+-----------+------------+--------------------+--------+
| https://172.17.6.25:2379 |  9a276cda24b26a1 |  3.5.13 |  509 MB |     false |      false |        13 |   21857962 |           21857962 |        |
| https://172.17.6.26:2379 | 3c9bfb292bb31b41 |  3.5.13 |  514 MB |      true |      false |        13 |   21857962 |           21857962 |        |
| https://172.17.6.27:2379 | 7604db99d94dd4ae |  3.5.13 |  567 MB |     false |      false |        13 |   21857962 |           21857962 |        |
+--------------------------+------------------+---------+---------+-----------+------------+-----------+------------+--------------------+--------+

======================================================================================
			****** Log collector PVC usage ******
======================================================================================

INFO:  log collector pvc has sufficient spac, however deleting old collections is always recommended

======================================================================================
			****** Frequent pod restarts ******
======================================================================================

NAMESPACE                                          NAME                                                                READY   STATUS      RESTARTS        AGE
cpd-instance                                       bamdev-cais-66b5c44c95-7p4db                                        2/2     Running     2 (24h ago)     45h
cpd-instance                                       zen-watcher-6fd4bd4b69-v4v24                                        2/2     Running     2 (11h ago)     2d22h
ibm-licensing                                      ibm-licensing-operator-6b8d675c98-xs8ql                             1/1     Running     1 (2d22h ago)   2d22h
ibm-spectrum-fusion-ns                             eventmanager-5d4c75bc64-mqzqv                                       1/1     Running     4 (138m ago)    6d5h
ibm-spectrum-fusion-ns                             eventmanager-5d4c75bc64-xqpqp                                       1/1     Running     2 (17h ago)     6d5h
nvidia-gpu-operator                                nvidia-dcgm-exporter-ph6q2                                          1/1     Running     1 (5d21h ago)   5d21h
open-cluster-management                            multicluster-integrations-7469d96d58-k5jrj                          3/3     Running     1 (2d23h ago)   2d23h
open-cluster-management                            multicluster-operators-application-7ffb87999f-kw9ls                 3/3     Running     2 (2d23h ago)   2d23h
open-cluster-management                            multicluster-operators-channel-5b6bbb9c6b-9vnf6                     1/1     Running     1 (2d23h ago)   2d23h
open-cluster-management                            multicluster-operators-hub-subscription-7bc8fb8ccc-7wccw            1/1     Running     1 (2d23h ago)   2d23h
open-cluster-management                            search-postgres-cb59bf665-9zn55                                     1/1     Running     5 (3h3m ago)    2d23h
openshift-cluster-node-tuning-operator             tuned-6r6hn                                                         1/1     Running     1               6d20h
openshift-cluster-node-tuning-operator             tuned-jf998                                                         1/1     Running     1               6d20h
openshift-cluster-node-tuning-operator             tuned-qxp27                                                         1/1     Running     1               6d20h
openshift-cnv                                      ssp-operator-685fb74fb-hbt94                                        1/1     Running     1 (5d3h ago)    5d6h
openshift-dns                                      dns-default-kbkhr                                                   2/2     Running     2               6d19h
openshift-dns                                      dns-default-l2969                                                   2/2     Running     2               6d19h
openshift-dns                                      dns-default-vz5xl                                                   2/2     Running     2               6d19h
openshift-dns                                      node-resolver-65qxs                                                 1/1     Running     1               6d19h
openshift-dns                                      node-resolver-9tjcw                                                 1/1     Running     1               6d19h
openshift-dns                                      node-resolver-lsn5h                                                 1/1     Running     1               6d19h
openshift-etcd                                     etcd-control-1-ru2.rackm06.mydomain.com                             4/4     Running     4               6d20h
openshift-etcd                                     etcd-control-1-ru3.rackm06.mydomain.com                             4/4     Running     4               6d20h
openshift-etcd                                     etcd-control-1-ru4.rackm06.mydomain.com                             4/4     Running     4               6d20h
openshift-image-registry                           node-ca-g5vks                                                       1/1     Running     1               6d20h
openshift-image-registry                           node-ca-h4ghj                                                       1/1     Running     1               6d20h
openshift-image-registry                           node-ca-nh2dh                                                       1/1     Running     1               6d20h
openshift-ingress-canary                           ingress-canary-6fm8p                                                1/1     Running     1               6d20h
openshift-ingress-canary                           ingress-canary-94b5q                                                1/1     Running     1               6d20h
openshift-ingress-canary                           ingress-canary-krwrj                                                1/1     Running     1               6d20h
openshift-kni-infra                                coredns-control-1-ru2.rackm06.mydomain.com                          2/2     Running     2               6d19h
openshift-kni-infra                                coredns-control-1-ru3.rackm06.mydomain.com                          2/2     Running     2               6d19h
openshift-kni-infra                                coredns-control-1-ru4.rackm06.mydomain.com                          2/2     Running     2               6d19h
openshift-kni-infra                                haproxy-control-1-ru2.rackm06.mydomain.com                          2/2     Running     2               6d19h
openshift-kni-infra                                haproxy-control-1-ru3.rackm06.mydomain.com                          2/2     Running     2               6d19h
openshift-kni-infra                                haproxy-control-1-ru4.rackm06.mydomain.com                          2/2     Running     2               6d19h
openshift-kni-infra                                keepalived-control-1-ru2.rackm06.mydomain.com                       2/2     Running     2               6d19h
openshift-kni-infra                                keepalived-control-1-ru3.rackm06.mydomain.com                       2/2     Running     2               6d19h
openshift-kni-infra                                keepalived-control-1-ru4.rackm06.mydomain.com                       2/2     Running     2               6d19h
openshift-kube-controller-manager                  kube-controller-manager-control-1-ru2.rackm06.mydomain.com          4/4     Running     4               6d20h
openshift-kube-controller-manager                  kube-controller-manager-control-1-ru3.rackm06.mydomain.com          4/4     Running     5 (102m ago)    6d20h
openshift-kube-controller-manager                  kube-controller-manager-control-1-ru4.rackm06.mydomain.com          4/4     Running     4               6d20h
openshift-kube-scheduler                           openshift-kube-scheduler-control-1-ru2.rackm06.mydomain.com         3/3     Running     3               6d20h
openshift-kube-scheduler                           openshift-kube-scheduler-control-1-ru3.rackm06.mydomain.com         3/3     Running     3               6d20h
openshift-kube-scheduler                           openshift-kube-scheduler-control-1-ru4.rackm06.mydomain.com         3/3     Running     3               6d20h
openshift-machine-config-operator                  kube-rbac-proxy-crio-compute-1-ru10.rackm06.mydomain.com            1/1     Running     2 (6d17h ago)   6d17h
openshift-machine-config-operator                  kube-rbac-proxy-crio-compute-1-ru11.rackm06.mydomain.com            1/1     Running     2 (6d17h ago)   6d17h
openshift-machine-config-operator                  kube-rbac-proxy-crio-compute-1-ru25.rackm06.mydomain.com            1/1     Running     2 (6d18h ago)   6d17h
openshift-machine-config-operator                  kube-rbac-proxy-crio-compute-1-ru5.rackm06.mydomain.com             1/1     Running     2 (6d17h ago)   6d17h
openshift-machine-config-operator                  kube-rbac-proxy-crio-compute-1-ru6.rackm06.mydomain.com             1/1     Running     2 (6d17h ago)   6d17h
openshift-machine-config-operator                  kube-rbac-proxy-crio-compute-1-ru7.rackm06.mydomain.com             1/1     Running     2 (6d17h ago)   6d17h
openshift-machine-config-operator                  kube-rbac-proxy-crio-compute-1-ru8.rackm06.mydomain.com             1/1     Running     2 (6d17h ago)   6d17h
openshift-machine-config-operator                  kube-rbac-proxy-crio-compute-1-ru9.rackm06.mydomain.com             1/1     Running     2 (6d17h ago)   6d17h
openshift-machine-config-operator                  kube-rbac-proxy-crio-control-1-ru2.rackm06.mydomain.com             1/1     Running     1               6d19h
openshift-machine-config-operator                  kube-rbac-proxy-crio-control-1-ru3.rackm06.mydomain.com             1/1     Running     1               6d19h
openshift-machine-config-operator                  kube-rbac-proxy-crio-control-1-ru4.rackm06.mydomain.com             1/1     Running     1               6d19h
openshift-machine-config-operator                  machine-config-daemon-7vxv9                                         2/2     Running     2               6d19h
openshift-machine-config-operator                  machine-config-daemon-gzw62                                         2/2     Running     2               6d19h
openshift-machine-config-operator                  machine-config-daemon-tcgfg                                         2/2     Running     2               6d19h
openshift-machine-config-operator                  machine-config-server-cfmz5                                         1/1     Running     1               6d19h
openshift-machine-config-operator                  machine-config-server-hwq9p                                         1/1     Running     1               6d19h
openshift-machine-config-operator                  machine-config-server-m766h                                         1/1     Running     1               6d19h
openshift-monitoring                               node-exporter-kvkz2                                                 2/2     Running     2               6d20h
openshift-monitoring                               node-exporter-r59fc                                                 2/2     Running     2               6d20h
openshift-monitoring                               node-exporter-wrnc4                                                 2/2     Running     2               6d20h
openshift-multus                                   multus-9wsz5                                                        1/1     Running     2               6d19h
openshift-multus                                   multus-additional-cni-plugins-8zgjd                                 1/1     Running     1               6d19h
openshift-multus                                   multus-additional-cni-plugins-g6wkt                                 1/1     Running     1               6d19h
openshift-multus                                   multus-additional-cni-plugins-lv7pl                                 1/1     Running     1               6d19h
openshift-multus                                   multus-b6jcw                                                        1/1     Running     2               6d19h
openshift-multus                                   multus-dsjkc                                                        1/1     Running     2               6d19h
openshift-multus                                   network-metrics-daemon-dbv9k                                        2/2     Running     2               6d19h
openshift-multus                                   network-metrics-daemon-vtf8x                                        2/2     Running     2               6d19h
openshift-multus                                   network-metrics-daemon-wtz62                                        2/2     Running     2               6d19h
openshift-multus                                   whereabouts-reconciler-4gthz                                        1/1     Running     3 (6d17h ago)   6d17h
openshift-multus                                   whereabouts-reconciler-dxnn7                                        1/1     Running     2 (6d17h ago)   6d17h
openshift-multus                                   whereabouts-reconciler-g8g2p                                        1/1     Running     1               6d19h
openshift-multus                                   whereabouts-reconciler-g9tpx                                        1/1     Running     1               6d19h
openshift-multus                                   whereabouts-reconciler-gfm2g                                        1/1     Running     2 (6d17h ago)   6d17h
openshift-multus                                   whereabouts-reconciler-lhtgs                                        1/1     Running     2 (6d18h ago)   6d18h
openshift-multus                                   whereabouts-reconciler-n28w9                                        1/1     Running     2 (6d17h ago)   6d17h
openshift-multus                                   whereabouts-reconciler-pl9vq                                        1/1     Running     1               6d19h
openshift-multus                                   whereabouts-reconciler-rvtpv                                        1/1     Running     2 (6d17h ago)   6d17h
openshift-multus                                   whereabouts-reconciler-vzkcm                                        1/1     Running     3 (6d17h ago)   6d17h
openshift-multus                                   whereabouts-reconciler-zgc6l                                        1/1     Running     3 (6d17h ago)   6d17h
openshift-network-diagnostics                      network-check-target-rnmwz                                          1/1     Running     1               6d19h
openshift-network-diagnostics                      network-check-target-rv5f6                                          1/1     Running     1               6d19h
openshift-network-diagnostics                      network-check-target-xtblb                                          1/1     Running     1               6d19h
openshift-network-node-identity                    network-node-identity-4qh8k                                         2/2     Running     3               6d19h
openshift-network-node-identity                    network-node-identity-f7gqm                                         2/2     Running     3 (102m ago)    6d19h
openshift-network-node-identity                    network-node-identity-pc6fv                                         2/2     Running     2               6d19h
openshift-network-operator                         iptables-alerter-bkt9f                                              1/1     Running     1               6d19h
openshift-network-operator                         iptables-alerter-srnrl                                              1/1     Running     1               6d19h
openshift-network-operator                         iptables-alerter-x4j6d                                              1/1     Running     1               6d19h
openshift-ovn-kubernetes                           ovnkube-node-mw8gg                                                  8/8     Running     8               6d19h
openshift-ovn-kubernetes                           ovnkube-node-nm4g9                                                  8/8     Running     8               6d19h
openshift-ovn-kubernetes                           ovnkube-node-skg5j                                                  8/8     Running     8               6d19h
openshift-storage                                  csi-cephfsplugin-46fb9                                              2/2     Running     1 (6d5h ago)    6d5h
openshift-storage                                  csi-cephfsplugin-46vck                                              2/2     Running     1 (6d5h ago)    6d5h
openshift-storage                                  csi-cephfsplugin-4bxkd                                              2/2     Running     1 (6d5h ago)    6d5h
openshift-storage                                  csi-cephfsplugin-9skj8                                              2/2     Running     1 (6d5h ago)    6d5h
openshift-storage                                  csi-cephfsplugin-b7g7c                                              2/2     Running     1 (6d5h ago)    6d5h
openshift-storage                                  csi-cephfsplugin-cnmsb                                              2/2     Running     1 (6d5h ago)    6d5h
openshift-storage                                  csi-cephfsplugin-flxzk                                              2/2     Running     1 (6d5h ago)    6d5h
openshift-storage                                  csi-cephfsplugin-pj4b9                                              2/2     Running     1 (6d5h ago)    6d5h
openshift-storage                                  csi-cephfsplugin-provisioner-5b6cfc85c6-jmhbc                       5/5     Running     4 (6d5h ago)    6d5h
openshift-storage                                  csi-cephfsplugin-provisioner-5b6cfc85c6-s9lcg                       5/5     Running     4 (6d5h ago)    6d5h
openshift-storage                                  csi-cephfsplugin-rhb4v                                              2/2     Running     1 (6d5h ago)    6d5h
openshift-storage                                  csi-cephfsplugin-x4x9h                                              2/2     Running     1 (6d5h ago)    6d5h
openshift-storage                                  csi-cephfsplugin-z4czq                                              2/2     Running     1 (6d5h ago)    6d5h
openshift-storage                                  csi-rbdplugin-5t4dp                                                 3/3     Running     1 (6d5h ago)    6d5h
openshift-storage                                  csi-rbdplugin-66stt                                                 3/3     Running     2 (6d5h ago)    6d5h
openshift-storage                                  csi-rbdplugin-6zrrj                                                 3/3     Running     2 (6d5h ago)    6d5h
openshift-storage                                  csi-rbdplugin-7t4d7                                                 3/3     Running     2 (6d5h ago)    6d5h
openshift-storage                                  csi-rbdplugin-dcppq                                                 3/3     Running     2 (6d5h ago)    6d5h
openshift-storage                                  csi-rbdplugin-g9slg                                                 3/3     Running     2 (6d5h ago)    6d5h
openshift-storage                                  csi-rbdplugin-glz8n                                                 3/3     Running     1 (6d5h ago)    6d5h
openshift-storage                                  csi-rbdplugin-pdxx8                                                 3/3     Running     2 (6d5h ago)    6d5h
openshift-storage                                  csi-rbdplugin-provisioner-5764589f6c-pglxv                          6/6     Running     5 (6d5h ago)    6d5h
openshift-storage                                  csi-rbdplugin-r7566                                                 3/3     Running     2 (6d5h ago)    6d5h
openshift-storage                                  csi-rbdplugin-s45r9                                                 3/3     Running     2 (6d5h ago)    6d5h
openshift-storage                                  csi-rbdplugin-t84k7                                                 3/3     Running     2 (6d5h ago)    6d5h

======================================================================================
			****** Critical events ******
======================================================================================

INFO:   ⏳ No critical events found

======================================================================================
			****** Critical alerts ******
======================================================================================

"NodeClockNotSynchronising"
"Clock at control-1-ru2.rackm06.mydomain.com is not synchronising. Ensure NTP is configured on this host."
"PodDisruptionBudgetLimit"
"The pod disruption budget is below the minimum disruptions allowed level and is not satisfied. The number of current healthy pods is less than the desired healthy pods."

========================================================================================
Healthcheck for IBM Storage Fusion HCI cluster completed at 2024-07-22 -0400 08:25:58 AM
========================================================================================

```