### PR TITLE
Restore fails in restic accessing lost+found directory

### DIFF
--- a/backup-restore/hotfixes/2.8.1/br-post-install-patch281.sh
+++ b/backup-restore/hotfixes/2.8.1/br-post-install-patch281.sh
@@ -37,7 +37,7 @@ if (oc get configmap -n "$BR_NS" guardian-dm-image-config -o yaml > guardian-dm-
  then
     echo "Scaling down guardian-dm-controller-manager deployment..."
     oc scale deployment guardian-dm-controller-manager -n "$BR_NS" --replicas=0
-    oc set data -n "$BR_NS" cm/guardian-dm-image-config DM_IMAGE=cp.icr.io/cp/fbr/guardian-datamover@sha256:b051b665b42ce81ab543558b8f7c2ddf36dfc7a95df887ef8583da2912849c5e
+    oc set data -n "$BR_NS" cm/guardian-dm-image-config DM_IMAGE=cp.icr.io/cpopen/guardian-datamover@sha256:b74504fec29de130ada1262d2fc3587660176f32526968e6efb68766d2d97e7c
     echo "Scaling up guardian-dm-controller-manager deployment..."
     oc scale deployment guardian-dm-controller-manager -n "$BR_NS" --replicas=1
 else


### PR DESCRIPTION
Restore fails with error "`xattr.LRemove /data/ibm-cs-postgres-backup/lost+found security.selinux: permission denied`"  in dm-controller pod:
```
{"level":"debug","ts":"2024-09-23T20:51:38Z","logger":"datamover","msg":"Execute command","command":"/restic","args":["-r","s3:https://s3.us-south.cloud-object-storage.appdomain.cloud/1296-cpd-cet/0c0f3b97-3a3a-4e41-84a9-fab05b0ccf1b/c968d846-75df-4219-8b7a-670d29ead8ff","--json","restore","b67efc4093448601882d84b1450b4c69d8f047767e18e41597758238a06b41c9","--target","/data/ibm-cs-postgres-backup"]}
{"level":"debug","ts":"2024-09-23T20:51:45Z","logger":"datamover.Restic stderr","msg":"{\"message_type\":\"error\",\"error\":{\"message\":\"xattr.LRemove /data/ibm-cs-postgres-backup/lost+found security.selinux: permission denied\"},\"during\":\"restore\",\"item\":\"/lost+found\"}","line":1}
{"level":"debug","ts":"2024-09-23T20:51:45Z","logger":"datamover.Restic stdout","msg":"{\"message_type\":\"summary\",\"total_files\":1}","line":1}
{"level":"info","ts":"2024-09-23T20:51:45Z","logger":"datamover.Restic stdout","msg":"Restic stdout","summary":"{\"message_type\":\"summary\",\"total_files\":1}"}
{"level":"debug","ts":"2024-09-23T20:51:45Z","logger":"datamover.Restic stderr","msg":"Fatal: There were 1 errors","line":2}
```