### PR TITLE
Remove Velero BackupRepositories during uninstall

### DIFF
--- a/backup-restore/uninstall/uninstall-backup-restore.sh
+++ b/backup-restore/uninstall/uninstall-backup-restore.sh
@@ -135,6 +135,12 @@ EOF
       sleep 5
       UNFINISHED=$(oc -n "$ISF_NS" get fdbr -o custom-columns=NAME:metadata.name,STATUS:status.phase --no-headers | grep -ivE "$IGNORE_DBR_STATES" )
     done
+
+    BACKUPREPOSITORIES=$(oc -n "$NAMESPACE" get backuprepositories.velero.io -o name --no-headers)
+    for BACKUPREPO in ${BACKUPREPOSITORIES[@]}; do
+        echo "$BACKUPREPO"
+        oc delete -n "$NAMESPACE" "$BACKUPREPO"
+    done
 fi
 
 oc -n "$ISF_NS" patch --type json configmap isf-data-protection-config -p '[{"op": "replace", "path": "/data/Mode", "value": "DisableWebhook"}]'


### PR DESCRIPTION
During backup Velero using the BackupRepositories object to determine if should connect or connect and initialize a repo.

During uninstall backups are removed but the BackupRepository object is not.

This causes on reinstall a connect with no initialization.  

There is no action by the Velero BackupRepository controller on uninstall except for removing the finalizer. There is no phases for deletion in progress.

New backups on existing repositories after installation with no deleted backups results in successful BackupRepository recreation with no loss of data.