### PR TITLE
43296: Add 2.8.2 hotfix; Add patch to update minio

### DIFF
--- a/backup-restore/hotfixes/2.8.0/applypatch-280.sh
+++ b/backup-restore/hotfixes/2.8.0/applypatch-280.sh
@@ -59,3 +59,10 @@ oc set data -n $BR_NS cm/guardian-configmap datamoverJobpodEphemeralStorageReque
 oc set data -n $BR_NS cm/guardian-configmap datamoverJobpodMemoryRequest='4000Mi'
 oc set data -n $BR_NS cm/guardian-configmap datamoverJobpodMemoryRequestRes='4000Mi'
 
+if [[ -z "$SKIP_MINIO" ]];
+  then
+    echo "Saving old guardian-minio image to old-minio-image.txt"
+    oc get statefulset guardian-minio -n $BR_NS -o jsonpath="{.spec.template.spec.containers[0].image}" >> old-minio-image.txt
+    echo "Updating statefulset/guardian-minio image to quay.io/minio/minio@sha256:ea15e53e66f96f63e12f45509d2d2d8fad774808debb490f48508b3130bd22d3"
+    oc set image statefulset/guardian-minio -n $BR_NS minio=quay.io/minio/minio@sha256:ea15e53e66f96f63e12f45509d2d2d8fad774808debb490f48508b3130bd22d3
+fi

--- a/backup-restore/hotfixes/2.8.1/br-post-install-patch281.sh
+++ b/backup-restore/hotfixes/2.8.1/br-post-install-patch281.sh
@@ -62,6 +62,14 @@ oc scale deployment dbr-controller -n "$BR_NS" --replicas=1
 echo "Patching transaction-manager deployment..."
 oc patch deployment/transaction-manager -n $BR_NS -p '{"spec":{"template":{"spec":{"containers":[{"name":"transaction-manager","image":"cp.icr.io/cp/fbr/guardian-transaction-manager@sha256:656433641ceda21ee45469500b2b7040983c48d1e3ee50f809be5ab6f3ab527d"}]}}}}'
 
+if [[ -z "$SKIP_MINIO" ]];
+  then
+    echo "Saving old guardian-minio image to old-minio-image.txt"
+    oc get statefulset guardian-minio -n $BR_NS -o jsonpath="{.spec.template.spec.containers[0].image}" >> old-minio-image.txt  
+    echo "Updating statefulset/guardian-minio image to quay.io/minio/minio@sha256:ea15e53e66f96f63e12f45509d2d2d8fad774808debb490f48508b3130bd22d3"
+    oc set image statefulset/guardian-minio -n $BR_NS minio=quay.io/minio/minio@sha256:ea15e53e66f96f63e12f45509d2d2d8fad774808debb490f48508b3130bd22d3
+fi
+
 if (oc get deployment -n $BR_NS backuppolicy-deployment -o yaml > backuppolicy-deployment.save.yaml)
   then
     echo "Creating backup-policy service account..."

--- a/backup-restore/hotfixes/2.8.2/br-post-install-patch282.sh
+++ b/backup-restore/hotfixes/2.8.2/br-post-install-patch282.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+# Run this script on hub and spoke clusters to apply the latest hotfixes for 2.8.2 release.
+
+LOG=/tmp/br-post-install-patch-282_$$_log.txt
+exec &> >(tee -a $LOG)
+echo "Writing output of br-post-install-patch-282.sh script to $LOG"
+
+ISF_NS=$(oc get spectrumfusion -A -o custom-columns=NS:metadata.namespace --no-headers)
+
+if [ -z "$ISF_NS" ]; then
+    echo "ERROR: No Successful Fusion installation found. Exiting."
+    exit 1
+fi
+
+BR_NS=$(oc get dataprotectionagent -A --no-headers -o custom-columns=NS:metadata.namespace)
+
+if (oc get deployment -n $BR_NS backup-location-deployment -o yaml > backup-location-deployment.save.yaml)
+  then
+    echo "Patching backup-location-deployment image..."
+    oc patch deployment backup-location-deployment -n $BR_NS -p '{"spec":{"template":{"spec":{"containers":[{"name":"backup-location-container","image":"cp.icr.io/cp/fbr/guardian-backup-location@sha256:c737450b02a9f415a4c4eea6cc6a67ce0723a8bf5c08ce41469c847c5b598e16"}]}}}}'
+else
+    echo "ERROR: Failed to save original backup-location-deployment. Skipped updates."
+fi
+
+if (oc get deployment -n $BR_NS backuppolicy-deployment -o yaml > backuppolicy-deployment.save.yaml)
+  then
+    echo "Creating backup-policy service account..."
+    oc create sa backup-policy -n $BR_NS
+
+    echo "Creating backup-policy-role cluster role..."
+    oc create clusterrole backup-policy-role --verb=get --resource=configmaps
+
+    echo "Creating backup-policy-rolebinding cluster role binding..."
+    oc adm policy add-cluster-role-to-user backup-policy-role -z backup-policy  -n $BR_NS --rolebinding-name=backup-policy-rolebinding
+
+    echo "Patching backuppolicy-deployment service account..."
+    oc patch deployment backuppolicy-deployment -n $BR_NS -p '{"spec":{"template":{"spec":{"serviceAccountName":"backup-policy"}}}}'
+
+    echo "Patching backuppolicy-deployment image..."
+    oc patch deployment backuppolicy-deployment -n $BR_NS -p '{"spec":{"template":{"spec":{"containers":[{"name":"backuppolicy-container","image":"cp.icr.io/cp/fbr/guardian-backup-policy@sha256:32a4ffba0dd2da241bd128ab694fd6fc34a7087aab053a29658e3e0f69ef11aa"}]}}}}'
+else
+    echo "ERROR: Failed to save original backuppolicy-deployment. Skipped updates."
+fi
+
+if (oc get deployment -n $BR_NS backup-service -o yaml > backup-service-deployment.save.yaml)
+  then
+    echo "Patching backup-service image..."
+    oc patch deployment backup-service -n $BR_NS -p '{"spec":{"template":{"spec":{"containers":[{"name":"backup-service","image":"cp.icr.io/cp/fbr/guardian-backup-service@sha256:742367383260fa25fdf1a7cf94a78267361519720869bb6cceac7476b5d5fab3"}]}}}}'
+else
+    echo "ERROR: Failed to save original backup-service deployment. Skipped updates."
+fi
+
+if (oc get deployment -n $BR_NS transaction-manager -o yaml > transaction-manager-deployment.save.yaml)
+  then
+    echo "Patching transaction-manager image..."
+    oc patch deployment/transaction-manager -n $BR_NS -p '{"spec":{"template":{"spec":{"containers":[{"name":"transaction-manager","image":"cp.icr.io/cp/fbr/guardian-transaction-manager@sha256:0ae46fc2f6e744f79f81005579f4dcb7c9981b201f239433bf1e132f9c89c8cd"}]}}}}'
+else
+    echo "ERROR: Failed to save original transaction-manager deployment. Skipped updates."
+fi
+
+if (oc get recipes.spp-data-protection.isf.ibm.com fusion-control-plane -n $ISF_NS -o yaml > fusion-control-plane-recipe.save.yaml)
+  then
+    echo "Patching fusion-control-plane recipe..."
+    oc patch recipes.spp-data-protection.isf.ibm.com fusion-control-plane -n $ISF_NS --type=merge -p '{"spec":{"hooks":[{"name":"fbr-hooks","nameSelector":"transaction-manager.*","namespace":"${FBR_NAMESPACE}","onError":"fail","ops":[{"command":"[\"/usr/src/app/code/.venv/bin/python3\",\"/usr/src/app/code/ctl-plane.pyc\",\"backup\",\"uid=${BACKUP_ID}\"]","container":"transaction-manager","name":"export-backup-inventory"},{"command":"[\"/usr/src/app/code/.venv/bin/python3\",\"/usr/src/app/code/ctl-plane.pyc\",\"restore\",\"uid=${BACKUP_ID}\"]","container":"transaction-manager","name":"restore-backup-inventory"},{"command":"[\"/usr/src/app/code/.venv/bin/python3\",\"/usr/src/app/code/ctl-plane.pyc\",\"deleteCRs\"]","container":"transaction-manager","name":"deleteCRs"}],"selectResource":"pod","singlePodOnly":true,"timeout":28800,"type":"exec"},{"name":"isf-dp-operator-hook","nameSelector":"transaction-manager.*","namespace":"${FBR_NAMESPACE}","onError":"fail","ops":[{"command":"[\"/usr/src/app/code/.venv/bin/python3\",\"/usr/src/app/code/patch-isd-dp-cm.pyc\",\"${PARENT_NAMESPACE}\",\"isf-data-protection-config\",\"DisableWebhook\"]","container":"transaction-manager","name":"disable-webhook"},{"command":"[\"/usr/src/app/code/.venv/bin/python3\",\"/usr/src/app/code/patch-isd-dp-cm.pyc\",\"${PARENT_NAMESPACE}\",\"isf-data-protection-config\",\"Recover\"]","container":"transaction-manager","name":"quiesce-isf-dp-controller"},{"command":"[\"/usr/src/app/code/.venv/bin/python3\",\"/usr/src/app/code/patch-isd-dp-cm.pyc\",\"${PARENT_NAMESPACE}\",\"isf-data-protection-config\",\"Normal\"]","container":"transaction-manager","name":"unquiesce-isf-dp-controller"}],"selectResource":"pod","singlePodOnly":true,"type":"exec"}]}}'
+else
+    echo "ERROR: Failed to save original fusion-control-plane recipe. Skipped updates."
+fi
+
+if [[ -z "$SKIP_MINIO" ]];
+  then
+    echo "Saving old guardian-minio image to old-minio-image.txt"
+    oc get statefulset guardian-minio -n $BR_NS -o jsonpath="{.spec.template.spec.containers[0].image}" >> old-minio-image.txt
+    echo "Updating statefulset/guardian-minio image to quay.io/minio/minio@sha256:ea15e53e66f96f63e12f45509d2d2d8fad774808debb490f48508b3130bd22d3"
+    oc set image statefulset/guardian-minio -n $BR_NS minio=quay.io/minio/minio@sha256:ea15e53e66f96f63e12f45509d2d2d8fad774808debb490f48508b3130bd22d3
+fi


### PR DESCRIPTION
# Description

Hotfix to use an updated minio image. In current minio image exists a defect that delete requests for objects are returned as successful but are not removed from the PersistentVolumeClaim. This has been fixed upstream in minio.

Offline installers will need to mirror the new image before applying the patch.

```
quay.io/minio/minio:RELEASE.2024-10-02T17-50-41Z
quay.io/minio/minio@sha256:ea15e53e66f96f63e12f45509d2d2d8fad774808debb490f48508b3130bd22d3
```

## Testing

The patch was tested by running the if statement in its own bash script

#!/bin/bash

```
if [[ -z "$SKIP_MINIO" ]];
  then
    echo "Saving old guardian-minio image to old-minio-image.txt"
    oc get statefulset guardian-minio -n $BR_NS -o jsonpath="{.spec.template.spec.containers[0].image}" >> old-minio-image.txt
    echo "Updating statefulset/guardian-minio image to quay.io/minio/minio@sha256:ea15e53e66f96f63e12f45509d2d2d8fad774808debb490f48508b3130bd22d3"
    oc set image statefulset/guardian-minio -n $BR_NS minio=quay.io/minio/minio@sha256:ea15e53e66f96f63e12f45509d2d2d8fad774808debb490f48508b3130bd22d3
fi
```

Without skipping:
```bash
BR_NS="ibm-backup-restore" ./testminioupdate.sh
Saving old guardian-minio image to old-minio-image.txt
Updating statefulset/guardian-minio image...
```

With SKIP_MINIO variable:
```bash
SKIP_MINIO=true BR_NS="ibm-backup-restore" ./testminioupdate.sh
```

Image has been tested internally and is compatible with 2.8.0, 2.8.1, and 2.8.2. 

## Platforms

This image is supported on amd64, ppc64le, s390x, and arm64.