### PR TITLE
Restore fails with InvalidCopyID error

### DIFF
--- a/backup-restore/hotfixes/2.8.2/br-282patch-offline-mirror.sh
+++ b/backup-restore/hotfixes/2.8.2/br-282patch-offline-mirror.sh
@@ -12,6 +12,7 @@ TARGET_PATH="$1"
 export TARGET_PATH
 set -e
 
+skopeo copy --insecure-policy --preserve-digests --all docker://icr.io/cpopen/guardian-datamover@sha256:c3bf9eda73aedaa8dd853424bfb30fc11cbcb53898a4375529f1126e1a18b5bf docker://$TARGET_PATH/guardian-datamover@sha256:c3bf9eda73aedaa8dd853424bfb30fc11cbcb53898a4375529f1126e1a18b5bf
 skopeo copy --insecure-policy --preserve-digests --all docker://cp.icr.io/cp/fbr/guardian-job-manager@sha256:5a99629999105bdc83862f4bf37842b8004dfb3db9eea20b07ab7e39e95c8edc docker://$TARGET_PATH/guardian-job-manager@sha256:5a99629999105bdc83862f4bf37842b8004dfb3db9eea20b07ab7e39e95c8edc
 skopeo copy --insecure-policy --preserve-digests --all docker://cp.icr.io/cp/fbr/guardian-backup-location@sha256:c737450b02a9f415a4c4eea6cc6a67ce0723a8bf5c08ce41469c847c5b598e16 docker://$TARGET_PATH/guardian-backup-location@sha256:c737450b02a9f415a4c4eea6cc6a67ce0723a8bf5c08ce41469c847c5b598e16
 skopeo copy --insecure-policy --preserve-digests --all docker://cp.icr.io/cp/fbr/guardian-backup-policy@sha256:32a4ffba0dd2da241bd128ab694fd6fc34a7087aab053a29658e3e0f69ef11aa docker://$TARGET_PATH/guardian-backup-policy@sha256:32a4ffba0dd2da241bd128ab694fd6fc34a7087aab053a29658e3e0f69ef11aa


### PR DESCRIPTION
Restore data mover fails within a few minutes with InvalidCopyID error due to repository being locked by dbr-controller pod:

```
ERROR: 2024/12/04 17:28:44 resticrepository.go:430: unable to create lock in backend: repository is already locked exclusively by PID 169 on dbr-controller-75ddfcb954-r6znh 
 {"level":"error","ts":"2024-12-04T17:29:46Z","logger":"datamover","msg":"Failed to retrieve Backup"
```
