### PR TITLE
Updates backup&restore hotfixes to handle issues with upgrades involving minio

### DIFF
--- a/backup-restore/hotfixes/2.8.0/applypatch-280.sh
+++ b/backup-restore/hotfixes/2.8.0/applypatch-280.sh
@@ -58,11 +58,3 @@ oc set data -n $BR_NS cm/guardian-configmap datamoverJobpodEphemeralStorageReque
 oc set data -n $BR_NS cm/guardian-configmap datamoverJobpodEphemeralStorageRequestRes='400Mi'
 oc set data -n $BR_NS cm/guardian-configmap datamoverJobpodMemoryRequest='4000Mi'
 oc set data -n $BR_NS cm/guardian-configmap datamoverJobpodMemoryRequestRes='4000Mi'
-
-if [[ -z "$SKIP_MINIO" ]];
-  then
-    echo "Saving old guardian-minio image to old-minio-image.txt"
-    oc get statefulset guardian-minio -n $BR_NS -o jsonpath="{.spec.template.spec.containers[0].image}" >> old-minio-image.txt
-    echo "Updating statefulset/guardian-minio image to quay.io/minio/minio@sha256:ea15e53e66f96f63e12f45509d2d2d8fad774808debb490f48508b3130bd22d3"
-    oc set image statefulset/guardian-minio -n $BR_NS minio=quay.io/minio/minio@sha256:ea15e53e66f96f63e12f45509d2d2d8fad774808debb490f48508b3130bd22d3
-fi

--- a/backup-restore/hotfixes/2.8.1/br-post-install-patch281.sh
+++ b/backup-restore/hotfixes/2.8.1/br-post-install-patch281.sh
@@ -86,14 +86,6 @@ oc scale deployment dbr-controller -n "$BR_NS" --replicas=1
 echo "Patching transaction-manager deployment..."
 oc patch deployment/transaction-manager -n $BR_NS -p '{"spec":{"template":{"spec":{"containers":[{"name":"transaction-manager","image":"cp.icr.io/cp/fbr/guardian-transaction-manager@sha256:be77eecb921b2e905e8ea5e0f6ca9b5b6bec76dc4b6cdde223e54e6c42840e97"}]}}}}'
 
-if [[ -z "$SKIP_MINIO" ]];
-  then
-    echo "Saving old guardian-minio image to old-minio-image.txt"
-    oc get statefulset guardian-minio -n $BR_NS -o jsonpath="{.spec.template.spec.containers[0].image}" >> old-minio-image.txt  
-    echo "Updating statefulset/guardian-minio image to quay.io/minio/minio@sha256:ea15e53e66f96f63e12f45509d2d2d8fad774808debb490f48508b3130bd22d3"
-    oc set image statefulset/guardian-minio -n $BR_NS minio=quay.io/minio/minio@sha256:ea15e53e66f96f63e12f45509d2d2d8fad774808debb490f48508b3130bd22d3
-fi
-
 if [ -n "$HUB" ]
   then
     echo "Apply patches to hub..."

--- a/backup-restore/hotfixes/2.8.2/br-post-install-patch-282.sh
+++ b/backup-restore/hotfixes/2.8.2/br-post-install-patch-282.sh
@@ -115,6 +115,8 @@ echo "Saving old guardian-minio image to old-minio-image.txt"
 oc get statefulset guardian-minio -n $BR_NS -o jsonpath="{.spec.template.spec.containers[0].image}" > $DIR/old-minio-image.txt
 echo "Updating statefulset/guardian-minio image to quay.io/minio/minio@sha256:ea15e53e66f96f63e12f45509d2d2d8fad774808debb490f48508b3130bd22d3"
 oc set image statefulset/guardian-minio -n $BR_NS minio=quay.io/minio/minio@sha256:ea15e53e66f96f63e12f45509d2d2d8fad774808debb490f48508b3130bd22d3
+oc delete pod -n $BR_NS -l app.kubernetes.io/component=minio
+oc rollout status -n $BR_NS --watch --timeout=600s statefulset/guardian-minio
 
 if (oc get configmap -n "$BR_NS" guardian-dm-image-config -o yaml > $DIR/guardian-dm-image-config-original.yaml)
  then


### PR DESCRIPTION
Remove minio from 2.8.0 and 2.8.1 due to downlevel minio on upgrade till hotfix is applied.

Delete minio pods and wait for them to restart after applying the image. In some versions of OpenShift the statefulset image update does not cause the pods to restart.

Output of script on update regarding minio:

```
Saving old guardian-minio image to old-minio-image.txt
Updating statefulset/guardian-minio image to quay.io/minio/minio@sha256:ea15e53e66f96f63e12f45509d2d2d8fad774808debb490f48508b3130bd22d3
pod "guardian-minio-0" deleted
Waiting for 1 pods to be ready...
partitioned roll out complete: 1 new pods have been updated...
```