### PR TITLE
44447 Create node-agent-configmap not in install

### DIFF
--- a/backup-restore/hotfixes/2.9.0/br-post-install-patch-290.sh
+++ b/backup-restore/hotfixes/2.9.0/br-post-install-patch-290.sh
@@ -139,7 +139,7 @@ if [[ "$VERSION" == 2.9.0* ]]; then
     if [ $NODEAGENTCONFIGFOUND -eq 1 ]; then
       echo "ConfigMap node-agent-config not found, creating it."
       oc create configmap node-agent-config --namespace "$BR_NS"
-      oc set data configmap/node-agent-config node-agent-config\.json='{"loadConcurrency":{"globalConfig":5},"podResources":{"cpuRequest":"2","cpuLimit":"4","memoryRequest":"4Gi","memoryLimit":"16Gi","ephemeralStorageRequest":"5Gi","ephemeralStorageLimit":"5Gi"}}'
+      oc set data --namespace "$BR_NS" configmap/node-agent-config node-agent-config\.json='{"loadConcurrency":{"globalConfig":5},"podResources":{"cpuRequest":"2","cpuLimit":"4","memoryRequest":"4Gi","memoryLimit":"16Gi","ephemeralStorageRequest":"5Gi","ephemeralStorageLimit":"5Gi"}}'
     fi 
     
     # force a reconcile by the the dataprotection agent to any custom settings in the DataProtectionAgent

--- a/backup-restore/hotfixes/2.9.0/br-post-install-patch-290.sh
+++ b/backup-restore/hotfixes/2.9.0/br-post-install-patch-290.sh
@@ -150,7 +150,8 @@ if [[ "$VERSION" == 2.9.0* ]]; then
     oc patch dataprotectionagent dpagent --namespace "$BR_NS" --type='json' -p='[{"op": "replace", "path": "/spec/datamoverConfiguration/datamoverPodConfig/podResources/cpuLimit", "value":"'${CPULIMIT}'"}]'
     let CPULIMIT=$CPULIMIT-1
     oc patch dataprotectionagent dpagent --namespace "$BR_NS" --type='json' -p='[{"op": "replace", "path": "/spec/datamoverConfiguration/datamoverPodConfig/podResources/cpuLimit", "value":"'${CPULIMIT}'"}]'
-    
+    # node-agent pod must restart to pickup the change
+    oc delete pod -l name=node-agent --namespace "$BR_NS"
 
     if [ -n "$HUB" ]
     then


### PR DESCRIPTION
The node-agent-config ConfigMap is used to set resource settings of the Kopia datamover. This ConfigMap is missing from the install.

The ConfigMap will get created if Ceph CephFS, IBM Storage Scale or NFS is detected during first backup or restore, but without the custom resource settings.

Changing the dpagent datamover resource settings does not create the ConfigMap.

This change fixes the issue by creating the ConfigMap and forces a reconcile to update the node-agent-config ConfigMap to the specified datamover settings in the Data Protection Agent.