### PR TITLE
Fixes kopia datamover not start due to pull policy Never (Issue: 44447)

### DIFF
--- a/backup-restore/hotfixes/2.9.0/br-290patch-offline-mirror.sh
+++ b/backup-restore/hotfixes/2.9.0/br-290patch-offline-mirror.sh
@@ -27,3 +27,5 @@ skopeo copy --insecure-policy --preserve-digests --all docker://cp.icr.io/cp/fus
 skopeo copy --insecure-policy --preserve-digests --all docker://cp.icr.io/cp/fusion-sds/isf-data-protection-operator@sha256:8d0d7ef3064271b948a4b9a3b05177ae959613a0b353062a286edb972112cfc4 docker://$TARGET_PATH/cp/fusion-sds/isf-data-protection-operator@sha256:8d0d7ef3064271b948a4b9a3b05177ae959613a0b353062a286edb972112cfc4
 
 skopeo copy --insecure-policy --preserve-digests --all docker://quay.io/minio/minio@sha256:ea15e53e66f96f63e12f45509d2d2d8fad774808debb490f48508b3130bd22d3 docker://$TARGET_PATH/minio/minio@sha256:ea15e53e66f96f63e12f45509d2d2d8fad774808debb490f48508b3130bd22d3
+
+skopeo copy --insecure-policy --preserve-digests --all docker://cp.icr.io/cp/bnr/fbr-velero@sha256:99c8ccf942196d813dae94edcd18ff05c4c76bdee2ddd2cbbe2da3fa2810dd49

--- a/backup-restore/hotfixes/2.9.0/hotfixes.txt
+++ b/backup-restore/hotfixes/2.9.0/hotfixes.txt
@@ -13,3 +13,4 @@ This hotfix fixes the following Backup & Restore issues:
     11. Service protection recipe incorrect on custom namespace installation.
     12. Job manager error checking for idle jobs.
     13. Error getting VirtualMachineSnapshot status.
+    14. Datamover (type: kopia) pod does not start due to node addition or replacement due to pull policy Never. (Issue#: 44447, 46425)


### PR DESCRIPTION
If nodes are replaced or added the datamover (type: kopia) does not start until the Velero image is manually mirrored to the replaced or added node. The pull policy has been updated.

This does not affect legacy (restic) datamovers.

Output from changes:

On first run the output of the added sections is:

```
Saved original OADP DataProtectionApplication configuration to ./velero-original.yaml
dataprotectionapplication.oadp.openshift.io/velero patched
Velero Deployement is restarting with replacement image
deployment.apps/velero condition met
```

If this script is run subsequently the output will change to:

```
Saved original OADP DataProtectionApplication configuration to ./velero-original.yaml
dataprotectionapplication.oadp.openshift.io/velero patched (no change)
Velero Deployement is restarting with replacement image
deployment.apps/velero condition met
```

The original OADP DataProtectionApplication configuration will be saved to velero-original.yaml.