### PR TITLE
Update velero path in br-290patch-offline-mirror.sh

### DIFF
--- a/backup-restore/hotfixes/2.9.0/br-290patch-offline-mirror.sh
+++ b/backup-restore/hotfixes/2.9.0/br-290patch-offline-mirror.sh
@@ -28,4 +28,4 @@ skopeo copy --insecure-policy --preserve-digests --all docker://cp.icr.io/cp/fus
 
 skopeo copy --insecure-policy --preserve-digests --all docker://quay.io/minio/minio@sha256:ea15e53e66f96f63e12f45509d2d2d8fad774808debb490f48508b3130bd22d3 docker://$TARGET_PATH/minio/minio@sha256:ea15e53e66f96f63e12f45509d2d2d8fad774808debb490f48508b3130bd22d3
 
-skopeo copy --insecure-policy --preserve-digests --all docker://cp.icr.io/cp/bnr/fbr-velero@sha256:99c8ccf942196d813dae94edcd18ff05c4c76bdee2ddd2cbbe2da3fa2810dd49
+skopeo copy --insecure-policy --preserve-digests --all docker://cp.icr.io/cp/bnr/fbr-velero@sha256:99c8ccf942196d813dae94edcd18ff05c4c76bdee2ddd2cbbe2da3fa2810dd49 docker://$TARGET_PATH/fbr-velero@sha256:99c8ccf942196d813dae94edcd18ff05c4c76bdee2ddd2cbbe2da3fa2810dd49


### PR DESCRIPTION
Fix for https://github.ibm.com/ProjectAbell/abell-tracking/issues/50187#issuecomment-110200375

Incorrect fbr-velero image mirror command in  br-290patch-offline-mirror.sh