### PR TITLE
handle job issues

### DIFF
--- a/backup-restore/hotfixes/2.9.1/br-291patch-offline-mirror.sh
+++ b/backup-restore/hotfixes/2.9.1/br-291patch-offline-mirror.sh
@@ -12,7 +12,7 @@ TARGET_PATH="$1"
 export TARGET_PATH
 set -e
 
-TRANSACTIONMANAGER=guardian-transaction-manager@sha256:b407e1c6585cc38938d52b750dddef57a97846edc4752b37da55014d1b9ef732
+TRANSACTIONMANAGER=guardian-transaction-manager@sha256:c935e0c4a2d9b29c86bacc9322bbd6330a7a30fcb8ccfce2d068abf082d2805e
 IDPSERVEROPERATOR=idp-server-operator@sha256:ec54933ec22c0b1175a1d017240401032caff5de0bdf99e7b5acea3a03686470
 
 declare -a IMAGES=(

--- a/backup-restore/hotfixes/2.9.1/br-post-install-patch-291.sh
+++ b/backup-restore/hotfixes/2.9.1/br-post-install-patch-291.sh
@@ -94,10 +94,19 @@ fi
 if (oc get deployment -n $BR_NS transaction-manager -o yaml > $DIR/transaction-manager-deployment.save.yaml)
 then
     echo "Patching deployment/transaction-manager image..."
-    oc set image deployment/transaction-manager --namespace $BR_NS transaction-manager=cp.icr.io/cp/bnr/guardian-transaction-manager@sha256:b407e1c6585cc38938d52b750dddef57a97846edc4752b37da55014d1b9ef732
+    oc set image deployment/transaction-manager --namespace $BR_NS transaction-manager=cp.icr.io/cp/bnr/guardian-transaction-manager@sha256:c935e0c4a2d9b29c86bacc9322bbd6330a7a30fcb8ccfce2d068abf082d2805e
     oc rollout status --namespace $BR_NS --timeout=65s deployment/transaction-manager
 else
     echo "ERROR: Failed to save original transaction-manager deployment. Skipped updates."
+fi
+
+if (oc get deployment -n $BR_NS dbr-controller -o yaml > $DIR/dbr-controller-deployment.save.yaml)
+then
+    echo "Patching deployment/dbr-controller image..."
+    oc set image deployment/dbr-controller --namespace $BR_NS dbr-controller=cp.icr.io/cp/bnr/guardian-transaction-manager@sha256:c935e0c4a2d9b29c86bacc9322bbd6330a7a30fcb8ccfce2d068abf082d2805e
+    oc rollout status --namespace $BR_NS --timeout=65s deployment/dbr-controller
+else
+    echo "ERROR: Failed to save original dbr-controller deployment. Skipped updates."
 fi
 
 if (oc get deployment -n $BR_NS ibm-dataprotectionserver-controller-manager -o yaml > $DIR/ibm-dataprotectionserver-controller-manager-deployment.save.yaml)
@@ -111,4 +120,5 @@ fi
 
 echo "Please verify that these pods have successfully restarted after hotfix update in their corresponding namespace:"
 printf "  %-25s: %s\n" "$BR_NS" "transaction-manager"
+printf "  %-25s: %s\n" "$BR_NS" "dbr-controller"
 printf "  %-25s: %s\n" "$BR_NS" "ibm-dataprotectionserver-controller-manager"

--- a/backup-restore/hotfixes/2.9.1/hotfixes.txt
+++ b/backup-restore/hotfixes/2.9.1/hotfixes.txt
@@ -2,3 +2,5 @@ This hotfix fixes the following Backup & Restore issues:
 
     1.  Restore fails with the error "failed to wait BackupRepository, errored early: more than one BackupRepository found" with kopia datamover (#45972). 
     2.  Handle SSL handshake failures between micro-services (#47567).
+    3.  After a commit failure exception, the Transaction-Manager and DBR-Controller pods will no longer consume new kafka messages and jobs will not be processed until after a manual restart
+    4.  Jobs that hit a PartiallyFailed recipe step fail entirely and stop processing the remaining steps of the recipe


### PR DESCRIPTION
Address following issues:
After a commit failure exception, the Transaction-Manager and DBR-Controller pods will no longer consume new kafka messages and jobs will not be processed until after a manual restart
Jobs that hit a PartiallyFailed recipe step fail entirely and stop processing the remaining steps of the recipe