### PR TITLE
Rework of fix for Scale filesystem path

### DIFF
--- a/backup-restore/hotfixes/2.9.1/br-291patch-offline-mirror.sh
+++ b/backup-restore/hotfixes/2.9.1/br-291patch-offline-mirror.sh
@@ -12,7 +12,7 @@ TARGET_PATH="$1"
 export TARGET_PATH
 set -e
 
-TRANSACTIONMANAGER=guardian-transaction-manager@sha256:f54cdc64c3acedb8ff8b1292d14f1e8c6b2af9c91feff35256a93d7567e03738
+TRANSACTIONMANAGER=guardian-transaction-manager@sha256:d64c38811669c178aec9aa8b60f439de376e3a47ccb67d7f1e170e1834bb2172
 IDPSERVEROPERATOR=idp-server-operator@sha256:ec54933ec22c0b1175a1d017240401032caff5de0bdf99e7b5acea3a03686470
 FBRVELERO=fbr-velero@sha256:877df338898d3164ddc389b1a4079f56b5cbd5f88cfa31ef4e17da1e5b70868f
 

--- a/backup-restore/hotfixes/2.9.1/br-post-install-patch-291.sh
+++ b/backup-restore/hotfixes/2.9.1/br-post-install-patch-291.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Run this script on hub and spoke clusters to apply the latest hotfixes for 2.9.1 release.
 # Refer to https://www.ibm.com/support/pages/node/7230021 for additional information.
-# Version 05-01-2025
+# Version 05-16-2025
 
 patch_usage() {
   echo "Usage: $0 (-hci |-sds | -help)"

--- a/backup-restore/hotfixes/2.9.1/br-post-install-patch-291.sh
+++ b/backup-restore/hotfixes/2.9.1/br-post-install-patch-291.sh
@@ -94,7 +94,7 @@ fi
 if (oc get deployment -n $BR_NS transaction-manager -o yaml > $DIR/transaction-manager-deployment.save.yaml)
 then
     echo "Patching deployment/transaction-manager image..."
-    oc set image deployment/transaction-manager --namespace $BR_NS transaction-manager=cp.icr.io/cp/bnr/guardian-transaction-manager@sha256:f54cdc64c3acedb8ff8b1292d14f1e8c6b2af9c91feff35256a93d7567e03738
+    oc set image deployment/transaction-manager --namespace $BR_NS transaction-manager=cp.icr.io/cp/bnr/guardian-transaction-manager@sha256:d64c38811669c178aec9aa8b60f439de376e3a47ccb67d7f1e170e1834bb2172
     oc rollout status --namespace $BR_NS --timeout=65s deployment/transaction-manager
 else
     echo "ERROR: Failed to save original transaction-manager deployment. Skipped updates."

--- a/backup-restore/hotfixes/2.9.1/hotfixes.txt
+++ b/backup-restore/hotfixes/2.9.1/hotfixes.txt
@@ -4,4 +4,4 @@ This hotfix fixes the following Backup & Restore issues:
     2.  Handle SSL handshake failures between micro-services (#47567).
     3.  After a commit failure exception, the Transaction-Manager and DBR-Controller pods will no longer consume new kafka messages and jobs will not be processed until after a manual restart
     4.  Jobs that hit a PartiallyFailed recipe step fail entirely and stop processing the remaining steps of the recipe
-    5.  File path in Scale file system is not set correctly for Scale PVC restored by kopia datamover
+    5.  File path in Scale file system is not set correctly for Scale PVC restored by kopia datamover (05/01 and 05/16)


### PR DESCRIPTION
File path in Scale file system is not set correctly for Scale PVC restored by kopia datamover