### PR TITLE
updated cas cleanup script

### DIFF
--- a/CAS/cas-cleanup/customer_cas_cleanup.sh
+++ b/CAS/cas-cleanup/customer_cas_cleanup.sh
@@ -35,6 +35,8 @@ set -euo pipefail
 NAMESPACE="ibm-cas"
 KEEP_PARADEDB=false
 KEEP_NAMESPACE=false
+RETRY_COUNT=5
+RETRY_INTERVAL=10
 
 # Help
 print_help() {
@@ -46,6 +48,24 @@ print_help() {
   echo "  --keep-namespace             Do NOT delete the namespace after cleanup"
   echo "  --help                       Display this help message"
   exit 0
+}
+
+# Run wrapper with error handling
+run_step() {
+  local step_name="$1"; shift
+  echo "============================================================"
+  echo "INFO" "Starting: $step_name"
+  echo "============================================================"
+  echo
+  if "$@"; then
+    echo
+    echo "============================================================"
+    echo "INFO" "Completed: $step_name"
+    echo "============================================================"
+  else
+    echo "ERROR" "Failed: $step_name (continuing to next step)"
+  fi
+  echo
 }
 
 # Parse arguments
@@ -106,77 +126,66 @@ echo "Current PVCs in namespace:"
 oc get pvc -n "$NAMESPACE"
 echo ""
 
+# Retry wrapper
+retry_until_gone() {
+  local resource=$1
+  local namespace=$2
+  local kind=$3
+
+  for i in $(seq 1 "$RETRY_COUNT"); do
+    if [[ -z "$namespace" ]]; then
+      if ! oc get "$kind" "$resource" &>/dev/null; then
+        echo "$kind/$resource deleted successfully."
+        return 0
+      fi
+    else
+      if ! oc get "$kind" "$resource" -n "$namespace" &>/dev/null; then
+        echo "$kind/$resource deleted successfully."
+        return 0
+      fi
+    fi
+    echo "[$i/$RETRY_COUNT] Waiting for $kind/$resource to terminate..."
+    sleep "$RETRY_INTERVAL"
+  done
+
+  echo "$kind/$resource did not delete after $RETRY_COUNT retries."
+  read -rp "Do you want to patch/remove finalizers and force delete $kind/$resource? [y/N]: " confirm
+  if [[ "$confirm" =~ ^[Yy]$ ]]; then
+    if [[ -z "$namespace" ]]; then
+      oc patch "$kind" "$resource" --type=merge -p '{"metadata":{"finalizers":[]}}' || true
+      oc delete "$kind" "$resource" --wait=false || true
+    else
+      oc patch "$kind" "$resource" -n "$namespace" --type=merge -p '{"metadata":{"finalizers":[]}}' || true
+      oc delete "$kind" "$resource" -n "$namespace" --wait=false || true
+    fi
+  fi
+}
+
 # Delete CAS CRs
 delete_custom_resources() {
   local CR_LIST
   CR_LIST=$(oc get CasInstall -n "$NAMESPACE" --no-headers -o custom-columns=":metadata.name" || true)
   for CR in $CR_LIST; do
     echo "Deleting CasInstall: $CR"
-    oc delete CasInstall "$CR" -n "$NAMESPACE" --wait=true || true
+    oc delete CasInstall "$CR" -n "$NAMESPACE" --wait=false || true
+    retry_until_gone "$CR" "$NAMESPACE" "CasInstall"
   done
 }
 
 # Delete Kafka-related resources with patching finalizers
 delete_kafka_resources() {
-  local TOPICS USERS KAFKAS
+  local RESOURCES=("kafkatopics.kafka.strimzi.io" "kafkauser.kafka.strimzi.io" "kafka.kafka.strimzi.io")
 
-  echo "Checking and deleting KafkaTopics..."
-  TOPICS=$(oc get kafkatopics.kafka.strimzi.io -n "$NAMESPACE" -o name || true)
-  for topic in $TOPICS; do
-    echo "Attempting to delete KafkaTopic: $topic"
-    oc delete "$topic" -n "$NAMESPACE" --wait=false || true
-  done
-
-  echo "Checking and deleting KafkaUsers..."
-  USERS=$(oc get kafkauser.kafka.strimzi.io -n "$NAMESPACE" -o name || true)
-  for user in $USERS; do
-    echo "Attempting to delete KafkaUser: $user"
-    oc delete "$user" -n "$NAMESPACE" --wait=false || true
-  done
-
-  echo "Checking and deleting Kafka clusters..."
-  KAFKAS=$(oc get kafka.kafka.strimzi.io -n "$NAMESPACE" -o name || true)
-  for kafka in $KAFKAS; do
-    echo "Attempting to delete Kafka: $kafka"
-    oc delete "$kafka" -n "$NAMESPACE" --wait=false || true
-  done
-
-  echo "Waiting 2 minutes before checking stuck resources..."
-  sleep 120
-
-  # Helper to check and patch stuck Kafka resource
-  patch_stuck_kafka_resource() {
-    local RESOURCE_TYPE=$1
-    local RESOURCE_LIST
-    RESOURCE_LIST=$(oc get "$RESOURCE_TYPE" -n "$NAMESPACE" -o name 2>/dev/null || true)
-
-    for res in $RESOURCE_LIST; do
-      DELETION_TIMESTAMP=$(oc get "$res" -n "$NAMESPACE" -o jsonpath='{.metadata.deletionTimestamp}' 2>/dev/null || true)
-      if [[ -n "$DELETION_TIMESTAMP" ]]; then
-        echo "Resource $res is stuck in Terminating (deletionTimestamp present)."
-        read -rp "Do you want to remove finalizers and force delete $res? [y/N]: " confirm
-        if [[ "$confirm" =~ ^[Yy]$ ]]; then
-          echo "Patching finalizers for $res"
-          oc patch "$res" -n "$NAMESPACE" --type=merge -p '{"metadata":{"finalizers":[]}}' || true
-          echo "Force deleting $res"
-          oc delete "$res" -n "$NAMESPACE" --wait=false || true
-        else
-          echo "Skipping $res as per user input."
-        fi
-      fi
+  for kind in "${RESOURCES[@]}"; do
+    local LIST
+    LIST=$(oc get "$kind" -n "$NAMESPACE" -o name || true)
+    for res in $LIST; do
+      echo "Deleting $res..."
+      oc delete "$res" -n "$NAMESPACE" --wait=false || true
+      retry_until_gone "${res#*/}" "$NAMESPACE" "$kind"
     done
-  }
-
-  echo "Checking for stuck KafkaTopics..."
-  patch_stuck_kafka_resource "kafkatopics.kafka.strimzi.io"
-
-  echo "Checking for stuck KafkaUsers..."
-  patch_stuck_kafka_resource "kafkauser.kafka.strimzi.io"
-
-  echo "Checking for stuck Kafka clusters..."
-  patch_stuck_kafka_resource "kafka.kafka.strimzi.io"
+  done
 }
-
 
 # Uninstall CAS operators
 uninstall_operators() {
@@ -185,62 +194,64 @@ uninstall_operators() {
   for sub in $SUBS; do
     CSV=$(oc get "$sub" -n "$NAMESPACE" -o jsonpath='{.status.installedCSV}' || true)
     echo "Deleting subscription: $sub"
-    oc delete "$sub" -n "$NAMESPACE" || true
+    oc delete "$sub" -n "$NAMESPACE" --wait=false || true
+    retry_until_gone "${sub#*/}" "$NAMESPACE" "Subscription"
     if [[ -n "$CSV" ]]; then
       echo "Deleting CSV: $CSV"
-      oc delete clusterserviceversion "$CSV" -n "$NAMESPACE" || true
+      oc delete clusterserviceversion "$CSV" -n "$NAMESPACE" --wait=false || true
+      retry_until_gone "$CSV" "$NAMESPACE" "clusterserviceversion"
     fi
   done
 }
 
-#Cleanup PVCs and PVs
+# Cleanup PVCs and PVs in parallel
 cleanup_pvcs() {
   local PVC_LIST
-  PVC_LIST=$(oc get pvc -n "$NAMESPACE" --no-headers -o custom-columns=":metadata.name")
+  PVC_LIST=$(oc get pvc -n "$NAMESPACE" --no-headers -o custom-columns=":metadata.name" || true)
+  local MAX_PARALLEL=5
+  local JOBS=0
 
   for pvc in $PVC_LIST; do
-    if [[ "$KEEP_PARADEDB" == true && "$pvc" == cluster-parade* ]]; then
-      echo "Skipping cluster-parade PVC: $pvc"
-      continue
-    fi
+    (
+      if [[ "$KEEP_PARADEDB" == true && "$pvc" == cluster-parade* ]]; then
+        echo "Skipping cluster-parade PVC: $pvc"
+        exit 0
+      fi
 
-    echo "Deleting PVC: $pvc"
-    oc delete pvc "$pvc" -n "$NAMESPACE" || true
+      echo "Deleting PVC: $pvc"
+      oc delete pvc "$pvc" -n "$NAMESPACE" --wait=false || true
+      retry_until_gone "$pvc" "$NAMESPACE" "pvc"
 
-    sleep 10  # Allow PVC deletion to settle
+      local PV
+      PV=$(oc get pv --no-headers -o custom-columns=":metadata.name,:spec.claimRef.name" | grep "$pvc" | awk '{print $1}' || true)
 
-    local PV
-    PV=$(oc get pv --no-headers -o custom-columns=":metadata.name,:spec.claimRef.name,:status.phase" | grep "$pvc" | awk '{print $1}' || true)
-
-    if [[ -n "$PV" ]]; then
-      echo "Checking PV $PV for cleanup..."
-      STATUS=$(oc get pv "$PV" -o jsonpath='{.status.phase}' || true)
-
-      if [[ "$STATUS" == "Released" ]]; then
-        echo "PV $PV is stuck in 'Released' state. Waiting 2 minutes before prompting..."
-        sleep 120
-
-        # Check if still Released
+      if [[ -n "$PV" ]]; then
+        echo "Found PV $PV for PVC $pvc"
         STATUS=$(oc get pv "$PV" -o jsonpath='{.status.phase}' || true)
+
         if [[ "$STATUS" == "Released" ]]; then
-          echo "PV $PV is still Released."
-          read -rp "Do you want to force delete PV $PV by removing finalizers? [y/N]: " confirm
+          read -rp "PV $PV is Released. Remove finalizers and delete? [y/N]: " confirm
           if [[ "$confirm" =~ ^[Yy]$ ]]; then
-            echo "Removing finalizers from PV $PV..."
             oc patch pv "$PV" -p '{"metadata":{"finalizers":null}}' --type=merge || true
-            echo "Deleting PV $PV..."
             oc delete pv "$PV" --wait=false || true
-          else
-            echo "Skipping PV $PV cleanup as per user request."
           fi
-        else
-          echo "PV $PV is no longer Released. Skipping force delete."
         fi
       fi
-    fi
-  done
-}
+    ) &
 
+    # increment job counter
+    JOBS=$((JOBS + 1))
+
+    # if we hit MAX_PARALLEL, wait for background jobs to finish before continuing
+    while [[ $(jobs -rp | wc -l) -ge $MAX_PARALLEL ]]; do
+      sleep 1
+    done
+  done
+
+  # wait for all remaining jobs
+  wait
+  echo "PVC and PV cleanup complete for namespace: $NAMESPACE"
+}
 
 # Function to delete FusionServiceInstance
 delete_fusion_service_instance() {
@@ -267,42 +278,85 @@ delete_catalog_source() {
 
 # Delete CAS-specific CRDs (safe approach)
 delete_cas_crds_only() {
-  echo "Checking CAS-specific CRDs (read-only list)..."
-  oc get crd | grep "cas.isf" || echo "None found (not deleting)"
+    echo "Looking for CAS-specific CRDs (excluding Kafka CRDs)..."
+    local CAS_CRDS
+    CAS_CRDS=$(oc get crd --no-headers -o custom-columns=":metadata.name" | grep -i "cas.isf" || true)
+
+    if [ -z "$CAS_CRDS" ]; then
+        echo "No CAS CRDs found."
+        return
+    fi
+
+    echo "Found the following CAS CRDs:"
+    echo "$CAS_CRDS"
+    echo
+    read -p "Do you want to delete these CAS CRDs? (y/n): " confirm
+    if [[ "$confirm" =~ ^[Yy]$ ]]; then
+        for crd in $CAS_CRDS; do
+            echo "Deleting CAS CRD: $crd..."
+            oc delete crd "$crd" --grace-period=0 || true
+        done
+        echo "CAS CRDs deleted."
+    else
+        echo "Skipping CAS CRD deletion."
+    fi
+}
+
+# Resource cleanup
+resource_cleanup() {
+    echo "Cleaning up all resources in namespace: $NAMESPACE..."
+
+    # Delete pods stuck in specific states (graceful delete)
+    oc get pods -n "$NAMESPACE" --no-headers | \
+        grep -E 'Running|CrashLoopBackOff|Pending|Failed' | \
+        awk '{print $1}' | \
+        xargs -r oc delete pod -n "$NAMESPACE" --grace-period=0
+
+    # Delete all other resources
+    oc delete pods --all -n "$NAMESPACE" --wait=true || true
+    oc delete secret --all -n "$NAMESPACE" --wait=true || true
+    oc delete configmap --all -n "$NAMESPACE" --wait=true || true
+    echo "Resource cleanup complete in namespace: $NAMESPACE"
 }
 
 # Final cleanup
 final_cleanup() {
-    echo "Cleaning up all resources in $NAMESPACE..."
+    echo "Cleaning up all resources in namespace: $NAMESPACE..."
 
-    oc delete all --all -n "$NAMESPACE" --wait=true || true
+    # Delete all resources
+    oc delete pods --all -n "$NAMESPACE" --wait=true || true
     oc delete pvc --all -n "$NAMESPACE" --wait=true || true
     oc delete secret --all -n "$NAMESPACE" --wait=true || true
     oc delete configmap --all -n "$NAMESPACE" --wait=true || true
-
-    echo "Resource cleanup complete."
+    oc delete all --all -n "$NAMESPACE" --wait=true || true
+    echo "Resource cleanup complete in namespace: $NAMESPACE"
 }
 
 # Delete namespace
 delete_namespace() {
   if [[ "$KEEP_NAMESPACE" == false ]]; then
     echo "Deleting Namespace: $NAMESPACE"
-    oc delete namespace "$NAMESPACE" || true
+    oc delete namespace "$NAMESPACE" --wait=false || true
+    retry_until_gone "$NAMESPACE" "" "namespace"
   else
     echo "Namespace $NAMESPACE preserved (--keep-namespace)."
   fi
 }
 
-### MAIN EXECUTION
-delete_custom_resources
-delete_catalog_source
-delete_cas_crds_only
-final_cleanup
-cleanup_pvcs
-delete_kafka_resources
-uninstall_operators
-delete_fusion_service_instance
-delete_namespace
+#######################################
+### MAIN EXECUTION FLOW #####
+#######################################
+
+run_step "Delete Custom Resources" delete_custom_resources
+run_step "Delete Catalog Source" delete_catalog_source
+run_step "Delete Kafka Resources" delete_kafka_resources
+run_step "Resource Cleanup" resource_cleanup
+run_step "Cleanup PVCs" cleanup_pvcs
+run_step "Uninstall Operators" uninstall_operators
+run_step "Delete CAS CRDs Only" delete_cas_crds_only
+run_step "Final Resource Cleanup" final_cleanup
+run_step "Delete Fusion Service Instance" delete_fusion_service_instance
+run_step "Delete Namespace" delete_namespace
 
 echo ""
 echo "IBM CAS gets cleaned up successfully."


### PR DESCRIPTION
```
   
kumar@Kumars-Laptop CAS % yes y | sh cas_uninstall.sh
============================================================
CAS Cleanup Script - Customer-Safe Version
Target Namespace: ibm-cas
Preserve cluster-parade Pods/PVCs: false
Preserve Namespace: false
============================================================

This script will perform the following operations:
- Uninstall CAS operator and related CRs in 'ibm-cas'
- Delete KafkaTopics, KafkaUsers, Kafka brokers (without force)
- Delete PVCs and their associated PVs (unless marked keep)
- Remove CAS catalog sources, CRDs (except shared/global ones)
- Optionally delete the entire namespace unless --keep-namespace is specified

Namespace 'ibm-cas' does not exist.
kumar@Kumars-Laptop CAS % yes y | sh cas_uninstall.sh
============================================================
CAS Cleanup Script - Customer-Safe Version
Target Namespace: ibm-cas
Preserve cluster-parade Pods/PVCs: false
Preserve Namespace: false
============================================================

This script will perform the following operations:
- Uninstall CAS operator and related CRs in 'ibm-cas'
- Delete KafkaTopics, KafkaUsers, Kafka brokers (without force)
- Delete PVCs and their associated PVs (unless marked keep)
- Remove CAS catalog sources, CRDs (except shared/global ones)
- Optionally delete the entire namespace unless --keep-namespace is specified

Current Pods in namespace:
NAME                                                              READY   STATUS      RESTARTS   AGE
9debfc751a63c91ce84f91c697fd1bde449f3e7bf8ff7c380fdb22ec002bqxq   0/1     Completed   0          11m
amq-streams-cluster-operator-v2.9.1-1-77f6856d45-gz4c9            1/1     Running     0          10m
cluster-parade-1                                                  1/1     Running     0          9m30s
cluster-parade-2                                                  1/1     Running     0          8m44s
cluster-parade-3                                                  1/1     Running     0          7m16s
cnpg-controller-manager-5f845bb4d7-tlf7l                          1/1     Running     0          10m
ibm-isf-cas-operator-catalog-8tqdt                                1/1     Running     0          12m
ibm-isf-cas-operator-controller-manager-68dc77659f-p5rh7          2/2     Running     0          10m
kafka-entity-operator-848f95dd5d-bfcdn                            2/2     Running     0          2m26s
kafka-kafka-0                                                     1/1     Running     0          3m7s
kafka-kafka-1                                                     1/1     Running     0          3m7s
kafka-kafka-2                                                     1/1     Running     0          3m7s
kafka-kafka-exporter-76bf54b674-79m4x                             1/1     Running     0          2m4s
kafka-zookeeper-0                                                 1/1     Running     0          3m47s
kafka-zookeeper-1                                                 1/1     Running     0          3m47s
kafka-zookeeper-2                                                 1/1     Running     0          3m47s
pooler-parade-rw-6f488f6b8d-9v56f                                 1/1     Running     0          4m20s
pooler-parade-rw-6f488f6b8d-q22vl                                 1/1     Running     0          4m20s
query-search-74dd84c976-bddvk                                     1/1     Running     0          4m20s
query-search-74dd84c976-dwqw7                                     1/1     Running     0          4m20s
query-search-74dd84c976-gwshq                                     1/1     Running     0          4m20s

Current PVCs in namespace:
NAME                     STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS          VOLUMEATTRIBUTESCLASS   AGE
cluster-parade-1         Bound    pvc-3b90d760-556b-4907-8807-4046ecbeac51   100Gi      RWO            ibm-spectrum-fusion   <unset>                 9m57s
cluster-parade-1-wal     Bound    pvc-8221b4e1-5850-49a0-b407-8398618e20e1   20Gi       RWO            ibm-spectrum-fusion   <unset>                 9m57s
cluster-parade-2         Bound    pvc-62af89a9-c08f-40e5-9db0-4f4fc40df72b   100Gi      RWO            ibm-spectrum-fusion   <unset>                 9m11s
cluster-parade-2-wal     Bound    pvc-1e054c60-7dff-41a0-a627-da762ccf5299   20Gi       RWO            ibm-spectrum-fusion   <unset>                 9m11s
cluster-parade-3         Bound    pvc-9d423acb-0d9d-472d-8d2b-e2d3deaecdac   100Gi      RWO            ibm-spectrum-fusion   <unset>                 8m26s
cluster-parade-3-wal     Bound    pvc-ab549907-caee-494f-a7ab-2764db850471   20Gi       RWO            ibm-spectrum-fusion   <unset>                 8m26s
data-kafka-kafka-0       Bound    pvc-f3d088fe-c6dc-4799-a114-3251e08477f0   60Gi       RWO            ibm-spectrum-fusion   <unset>                 3m9s
data-kafka-kafka-1       Bound    pvc-a2b87a60-2500-4c9b-b8cb-67971e68430e   60Gi       RWO            ibm-spectrum-fusion   <unset>                 3m9s
data-kafka-kafka-2       Bound    pvc-8497c4bf-1b12-4881-9123-1ef62c6ac9ac   60Gi       RWO            ibm-spectrum-fusion   <unset>                 3m9s
data-kafka-zookeeper-0   Bound    pvc-15e10db3-f92e-4341-aa11-f15ae18979a9   10Gi       RWO            ibm-spectrum-fusion   <unset>                 3m49s
data-kafka-zookeeper-1   Bound    pvc-b4cacc1b-f471-4f5f-af82-5d058c722846   10Gi       RWO            ibm-spectrum-fusion   <unset>                 3m49s
data-kafka-zookeeper-2   Bound    pvc-5e4100c7-5b8d-4653-b598-96264af7f2f0   10Gi       RWO            ibm-spectrum-fusion   <unset>                 3m49s

============================================================
INFO Starting: Delete Custom Resources
============================================================

Deleting CasInstall: ibm-cas-service-instance
casinstall.cas.isf.ibm.com "ibm-cas-service-instance" deleted
CasInstall/ibm-cas-service-instance deleted successfully.

============================================================
INFO Completed: Delete Custom Resources
============================================================

============================================================
INFO Starting: Delete Catalog Source
============================================================

Deleting CAS CatalogSource...
catalogsource.operators.coreos.com "ibm-isf-cas-operator-catalog" deleted

============================================================
INFO Completed: Delete Catalog Source
============================================================

============================================================
INFO Starting: Delete Kafka Resources
============================================================

Deleting kafkatopic.kafka.strimzi.io/cas-status...
kafkatopic.kafka.strimzi.io "cas-status" deleted
[1/5] Waiting for kafkatopics.kafka.strimzi.io/cas-status to terminate...
[2/5] Waiting for kafkatopics.kafka.strimzi.io/cas-status to terminate...
[3/5] Waiting for kafkatopics.kafka.strimzi.io/cas-status to terminate...
[4/5] Waiting for kafkatopics.kafka.strimzi.io/cas-status to terminate...
[5/5] Waiting for kafkatopics.kafka.strimzi.io/cas-status to terminate...
kafkatopics.kafka.strimzi.io/cas-status did not delete after 5 retries.
kafkatopic.kafka.strimzi.io/cas-status patched
Error from server (NotFound): kafkatopics.kafka.strimzi.io "cas-status" not found
Deleting kafkauser.kafka.strimzi.io/cas-user...
kafkauser.kafka.strimzi.io "cas-user" deleted
kafkauser.kafka.strimzi.io/cas-user deleted successfully.

============================================================
INFO Completed: Delete Kafka Resources
============================================================

============================================================
INFO Starting: Resource Cleanup
============================================================

Cleaning up all resources in namespace: ibm-cas...
pod "amq-streams-cluster-operator-v2.9.1-1-77f6856d45-gz4c9" deleted
pod "cluster-parade-1" deleted
pod "cluster-parade-2" deleted
pod "cluster-parade-3" deleted
pod "cnpg-controller-manager-5f845bb4d7-tlf7l" deleted
pod "ibm-isf-cas-operator-controller-manager-68dc77659f-p5rh7" deleted
pod "pooler-parade-rw-6f488f6b8d-9v56f" deleted
pod "pooler-parade-rw-6f488f6b8d-q22vl" deleted
pod "amq-streams-cluster-operator-v2.9.1-1-77f6856d45-l7z7w" deleted
pod "cluster-parade-1" deleted
pod "cnpg-controller-manager-5f845bb4d7-whf2r" deleted
pod "ibm-isf-cas-operator-controller-manager-68dc77659f-dz4tc" deleted
pod "pooler-parade-rw-6f488f6b8d-qqdn7" deleted
pod "pooler-parade-rw-6f488f6b8d-r5znh" deleted
persistentvolumeclaim "cluster-parade-1" deleted
persistentvolumeclaim "cluster-parade-1-wal" deleted
persistentvolumeclaim "cluster-parade-2" deleted
persistentvolumeclaim "cluster-parade-2-wal" deleted
persistentvolumeclaim "cluster-parade-3" deleted
persistentvolumeclaim "cluster-parade-3-wal" deleted
persistentvolumeclaim "data-kafka-kafka-0" deleted
persistentvolumeclaim "data-kafka-kafka-1" deleted
persistentvolumeclaim "data-kafka-kafka-2" deleted
persistentvolumeclaim "data-kafka-zookeeper-0" deleted
persistentvolumeclaim "data-kafka-zookeeper-1" deleted
persistentvolumeclaim "data-kafka-zookeeper-2" deleted

secret "builder-dockercfg-792xh" deleted
secret "cluster-parade-app" deleted
secret "cluster-parade-ca" deleted
secret "cluster-parade-dockercfg-jvssh" deleted
secret "cluster-parade-pooler" deleted
secret "cluster-parade-replication" deleted
secret "cluster-parade-server" deleted
secret "cnpg-controller-manager-service-cert" deleted
secret "cnpg-manager-dockercfg-gkps5" deleted
secret "default-dockercfg-7pvps" deleted
secret "deployer-dockercfg-7tg6h" deleted
secret "ibm-isf-cas-operator-controller-manager-dockercfg-7h5sh" deleted
secret "pooler-parade-rw-dockercfg-v6cfg" deleted
secret "strimzi-cluster-operator-dockercfg-rrn2j" deleted
configmap "cnpg-default-monitoring" deleted
configmap "fusion-config" deleted
configmap "kube-root-ca.crt" deleted
configmap "openshift-service-ca.crt" deleted
configmap "strimzi-cluster-operator" deleted
pod "amq-streams-cluster-operator-v2.9.1-1-77f6856d45-zjvrn" deleted
pod "cnpg-controller-manager-5bf9f784cb-2x9n6" deleted
pod "cnpg-controller-manager-5f845bb4d7-5xz7g" deleted
pod "ibm-isf-cas-operator-controller-manager-68dc77659f-9rqlw" deleted
pod "pooler-parade-rw-6f488f6b8d-vp5hd" deleted
pod "pooler-parade-rw-6f488f6b8d-zcwtt" deleted
service "cluster-parade-r" deleted
service "cluster-parade-ro" deleted
service "cluster-parade-rw" deleted
service "cnpg-controller-manager-service" deleted
service "cnpg-webhook-service" deleted
service "ibm-isf-cas-operator-controller-manager-metrics-service" deleted
service "pooler-parade-rw" deleted
deployment.apps "amq-streams-cluster-operator-v2.9.1-1" deleted
deployment.apps "cnpg-controller-manager" deleted
deployment.apps "ibm-isf-cas-operator-controller-manager" deleted
deployment.apps "pooler-parade-rw" deleted
Warning: apps.openshift.io/v1 DeploymentConfig is deprecated in v4.14+, unavailable in v4.10000+
Resource cleanup complete in namespace: ibm-cas

============================================================
INFO Completed: Resource Cleanup
============================================================

============================================================
INFO Starting: Cleanup PVCs
============================================================

PVC and PV cleanup complete for namespace: ibm-cas

============================================================
INFO Completed: Cleanup PVCs
============================================================

============================================================
INFO Starting: Uninstall Operators
============================================================

Deleting subscription: subscription.operators.coreos.com/cloudnative-pg-stable-v1-certified-operators-openshift-marketplace
subscription.operators.coreos.com "cloudnative-pg-stable-v1-certified-operators-openshift-marketplace" deleted
Subscription/cloudnative-pg-stable-v1-certified-operators-openshift-marketplace deleted successfully.
Deleting CSV: cloudnative-pg.v1.26.1
clusterserviceversion.operators.coreos.com "cloudnative-pg.v1.26.1" deleted
[1/5] Waiting for clusterserviceversion/cloudnative-pg.v1.26.1 to terminate...
clusterserviceversion/cloudnative-pg.v1.26.1 deleted successfully.
Error from server (NotFound): subscriptions.operators.coreos.com "ibm-isf-cas-operator" not found
Deleting subscription: subscription.operators.coreos.com/ibm-isf-cas-operator
Error from server (NotFound): subscriptions.operators.coreos.com "ibm-isf-cas-operator" not found
Subscription/ibm-isf-cas-operator deleted successfully.

============================================================
INFO Completed: Uninstall Operators
============================================================

============================================================
INFO Starting: Delete CAS CRDs Only
============================================================

Looking for CAS-specific CRDs (excluding Kafka CRDs)...
Found the following CAS CRDs:
casresourceaccesscontrols.cas.isf.ibm.com
datasources.cas.isf.ibm.com
documentprocessors.cas.isf.ibm.com
domains.cas.isf.ibm.com
identityproviders.cas.isf.ibm.com

Deleting CAS CRD: casresourceaccesscontrols.cas.isf.ibm.com...
Error from server (NotFound): customresourcedefinitions.apiextensions.k8s.io "casresourceaccesscontrols.cas.isf.ibm.com" not found
Deleting CAS CRD: datasources.cas.isf.ibm.com...
Error from server (NotFound): customresourcedefinitions.apiextensions.k8s.io "datasources.cas.isf.ibm.com" not found
Deleting CAS CRD: documentprocessors.cas.isf.ibm.com...
Error from server (NotFound): customresourcedefinitions.apiextensions.k8s.io "documentprocessors.cas.isf.ibm.com" not found
Deleting CAS CRD: domains.cas.isf.ibm.com...
Error from server (NotFound): customresourcedefinitions.apiextensions.k8s.io "domains.cas.isf.ibm.com" not found
Deleting CAS CRD: identityproviders.cas.isf.ibm.com...
Error from server (NotFound): customresourcedefinitions.apiextensions.k8s.io "identityproviders.cas.isf.ibm.com" not found
CAS CRDs deleted.

============================================================
INFO Completed: Delete CAS CRDs Only
============================================================

============================================================
INFO Starting: Resource Cleanup
============================================================

Cleaning up all resources in namespace: ibm-cas...
No resources found in ibm-cas namespace.
No resources found
No resources found
secret "builder-dockercfg-792xh" deleted
secret "cluster-parade-dockercfg-jvssh" deleted
secret "default-dockercfg-7pvps" deleted
secret "deployer-dockercfg-7tg6h" deleted
secret "pooler-parade-rw-dockercfg-v6cfg" deleted
configmap "kube-root-ca.crt" deleted
configmap "openshift-service-ca.crt" deleted
Warning: apps.openshift.io/v1 DeploymentConfig is deprecated in v4.14+, unavailable in v4.10000+
Resource cleanup complete in namespace: ibm-cas

============================================================
INFO Completed: Resource Cleanup
============================================================

============================================================
INFO Starting: Delete Fusion Service Instance
============================================================

Deleting FusionServiceInstance from ibm-spectrum-fusion-ns...
fusionserviceinstance.service.isf.ibm.com "ibm-cas-service-instance" deleted

============================================================
INFO Completed: Delete Fusion Service Instance
============================================================

============================================================
INFO Starting: Delete Namespace
============================================================

Deleting Namespace: ibm-cas
namespace "ibm-cas" deleted
[1/5] Waiting for namespace/ibm-cas to terminate...
namespace/ibm-cas deleted successfully.

============================================================
INFO Completed: Delete Namespace
============================================================


IBM CAS gets cleaned up successfully.
```