### PR TITLE
Retry logic to resource and fusion service instance

### DIFF
--- a/CAS/cas-cleanup/customer_cas_cleanup.sh
+++ b/CAS/cas-cleanup/customer_cas_cleanup.sh
@@ -306,11 +306,9 @@ delete_cas_crd_instances() {
             oc patch "$resource" "$name" -n "$NAMESPACE" --type=json \
                 -p='[{"op": "remove", "path": "/metadata/finalizers"}]' 2>/dev/null || true
 
-            # extra safety: force remove via merge
             oc patch "$resource" "$name" -n "$NAMESPACE" --type=merge \
                 -p '{"metadata":{"finalizers":[]}}' 2>/dev/null || true
 
-            # delete instance
             oc delete "$resource" "$name" -n "$NAMESPACE" --ignore-not-found=true --wait=false
 
             # wait until gone

--- a/CAS/cas-cleanup/customer_cas_cleanup.sh
+++ b/CAS/cas-cleanup/customer_cas_cleanup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 ###############################################################################
-# Script Name: cleanup-cas-customer.sh
+# Script Name: customer_cas_cleanup.sh
 # Purpose: Safely uninstall the CAS service from OpenShift without forcing deletion.
 #
 # FEATURES:
@@ -161,17 +161,6 @@ retry_until_gone() {
   fi
 }
 
-# Delete CAS CRs
-delete_custom_resources() {
-  local CR_LIST
-  CR_LIST=$(oc get CasInstall -n "$NAMESPACE" --no-headers -o custom-columns=":metadata.name" || true)
-  for CR in $CR_LIST; do
-    echo "Deleting CasInstall: $CR"
-    oc delete CasInstall "$CR" -n "$NAMESPACE" --wait=false || true
-    retry_until_gone "$CR" "$NAMESPACE" "CasInstall"
-  done
-}
-
 # Delete Kafka-related resources with patching finalizers
 delete_kafka_resources() {
   local RESOURCES=("kafkatopics.kafka.strimzi.io" "kafkauser.kafka.strimzi.io" "kafka.kafka.strimzi.io")
@@ -206,6 +195,7 @@ uninstall_operators() {
 
 # Cleanup PVCs and PVs in parallel
 cleanup_pvcs() {
+  echo "Starting PVC cleanup in namespace: $NAMESPACE"
   local PVC_LIST
   PVC_LIST=$(oc get pvc -n "$NAMESPACE" --no-headers -o custom-columns=":metadata.name" || true)
   local MAX_PARALLEL=5
@@ -222,35 +212,37 @@ cleanup_pvcs() {
       oc delete pvc "$pvc" -n "$NAMESPACE" --wait=false || true
       retry_until_gone "$pvc" "$NAMESPACE" "pvc"
 
+      # Handle associated PV
       local PV
       PV=$(oc get pv --no-headers -o custom-columns=":metadata.name,:spec.claimRef.name" | grep "$pvc" | awk '{print $1}' || true)
 
       if [[ -n "$PV" ]]; then
-        echo "Found PV $PV for PVC $pvc"
+        echo "Processing PV $PV linked to PVC $pvc"
+        local STATUS
         STATUS=$(oc get pv "$PV" -o jsonpath='{.status.phase}' || true)
+        echo "PV $PV status is $STATUS"
 
-        if [[ "$STATUS" == "Released" ]]; then
-          read -rp "PV $PV is Released. Remove finalizers and delete? [y/N]: " confirm
-          if [[ "$confirm" =~ ^[Yy]$ ]]; then
-            oc patch pv "$PV" -p '{"metadata":{"finalizers":null}}' --type=merge || true
-            oc delete pv "$PV" --wait=false || true
-          fi
+        if [[ "$STATUS" == "Released" || "$STATUS" == "Failed" || "$STATUS" == "Terminating" ]]; then
+          echo "PV $PV is in state $STATUS, removing finalizers if needed"
+          oc patch pv "$PV" --type=merge -p '{"metadata":{"finalizers":[]}}' || true
         fi
+
+        echo "Deleting PV $PV"
+        oc delete pv "$PV" --wait=false || true
+        retry_until_gone "$PV" "" "pv"
       fi
     ) &
 
-    # increment job counter
     JOBS=$((JOBS + 1))
 
-    # if we hit MAX_PARALLEL, wait for background jobs to finish before continuing
+    # Control parallel jobs
     while [[ $(jobs -rp | wc -l) -ge $MAX_PARALLEL ]]; do
       sleep 1
     done
   done
 
-  # wait for all remaining jobs
   wait
-  echo "PVC and PV cleanup complete for namespace: $NAMESPACE"
+  echo "PVC and PV cleanup complete in namespace: $NAMESPACE"
 }
 
 # Function to delete FusionServiceInstance
@@ -262,7 +254,9 @@ delete_fusion_service_instance() {
 
     if oc get fusionserviceinstance ibm-cas-service-instance -n "$fusion_ns" &>/dev/null; then
         echo "Deleting FusionServiceInstance from $fusion_ns..."
-        oc delete fusionserviceinstance ibm-cas-service-instance -n "$fusion_ns" --wait=true
+        # Delete without waiting, then retry until gone
+        oc delete fusionserviceinstance ibm-cas-service-instance -n "$fusion_ns" --wait=false || true
+        retry_until_gone "ibm-cas-service-instance" "$fusion_ns" "fusionserviceinstance"
     else
         echo "No FusionServiceInstance found in $fusion_ns."
     fi
@@ -278,7 +272,7 @@ delete_catalog_source() {
 
 # Delete CAS-specific CRD instances
 delete_cas_crd_instances() {
-    echo "Looking for CAS-specific CRDs (excluding Kafka CRDs)..."
+    echo "Looking for CAS-specific CRDs in namespace: $NAMESPACE (excluding Kafka CRDs)..."
     local CAS_CRDS
     CAS_CRDS=$(oc get crd --no-headers -o custom-columns=":metadata.name" | grep -i "cas.isf" || true)
 
@@ -298,47 +292,78 @@ delete_cas_crd_instances() {
 
         local instances
         instances=$(oc get "$resource" -n "$NAMESPACE" --no-headers \
-            -o custom-columns="NAMESPACE:.metadata.namespace,NAME:.metadata.name" 2>/dev/null || true)
+            -o custom-columns="NAME:.metadata.name" 2>/dev/null || true)
 
         if [ -z "$instances" ]; then
             echo "  No instances found for $resource in namespace $NAMESPACE"
             continue
         fi
 
-        echo "$instances" | while read -r ns name; do
-            echo "  Deleting $resource/$name in namespace $ns"
+        for name in $instances; do
+            echo "  Deleting $resource/$name in namespace $NAMESPACE"
 
             # remove all finalizers (json patch)
-            oc patch "$resource" "$name" -n "$ns" --type=json \
+            oc patch "$resource" "$name" -n "$NAMESPACE" --type=json \
                 -p='[{"op": "remove", "path": "/metadata/finalizers"}]' 2>/dev/null || true
 
-            oc patch "$resource" "$name" -n "$ns" --type=merge \
+            # extra safety: force remove via merge
+            oc patch "$resource" "$name" -n "$NAMESPACE" --type=merge \
                 -p '{"metadata":{"finalizers":[]}}' 2>/dev/null || true
 
-            oc delete "$resource" "$name" -n "$ns" --ignore-not-found=true --wait=false
+            # delete instance
+            oc delete "$resource" "$name" -n "$NAMESPACE" --ignore-not-found=true --wait=false
 
-            # Retry until gone
-            retry_until_gone "$resource" "$name" "$ns"
+            # wait until gone
+            retry_until_gone "$name" "$NAMESPACE" "$resource"
         done
     done
 }
 
-# Resource cleanup
+
+# resource cleanup with parallel flow
 resource_cleanup() {
-    echo "Cleaning up all resources in namespace: $NAMESPACE..."
+  echo "Starting resource cleanup in namespace: $NAMESPACE"
+  local MAX_PARALLEL=5
+  local active_jobs=0
 
-    # Delete pods stuck in specific states (graceful delete)
-    oc get pods -n "$NAMESPACE" --no-headers | \
-        grep -E 'Running|CrashLoopBackOff|Pending|Failed' | \
-        awk '{print $1}' | \
-        xargs -r oc delete pod -n "$NAMESPACE" --grace-period=0
+  control_parallel() {
+    while [[ $(jobs -rp | wc -l) -ge $MAX_PARALLEL ]]; do
+      sleep 1
+    done
+  }
 
-    # Delete all other resources
-    oc delete secret --all -n "$NAMESPACE" --wait=true || true
-    oc delete configmap --all -n "$NAMESPACE" --wait=true || true
-    oc delete domains --all -n "$NAMESPACE" --wait=true || true
-    oc delete datasource --all -n "$NAMESPACE" --wait=true || true
-    echo "Resource cleanup complete in namespace: $NAMESPACE"
+  # Delete pods stuck in certain states
+  oc get pods -n "$NAMESPACE" --no-headers | \
+    awk '{print $1, $3}' | \
+    while read -r pod status; do
+      if [[ "$status" =~ ^(Running|CrashLoopBackOff|Pending|Failed)$ ]]; then
+        control_parallel
+        (
+          echo "Deleting pod $pod"
+          oc delete pod "$pod" -n "$NAMESPACE" --grace-period=0 --wait=false || true
+          retry_until_gone "$pod" "$NAMESPACE" "pod"
+        ) &
+      fi
+    done
+
+  # List of resource types to delete
+  local resources=("secret" "configmap" "domains" "datasource")
+
+  for res in "${resources[@]}"; do
+    oc get "$res" -n "$NAMESPACE" --no-headers -o custom-columns=":metadata.name" 2>/dev/null | \
+    while read -r name; do
+      control_parallel
+      (
+        echo "Deleting $res/$name"
+        oc delete "$res" "$name" -n "$NAMESPACE" --wait=false || true
+        retry_until_gone "$name" "$NAMESPACE" "$res"
+      ) &
+    done
+  done
+
+  # Wait for all background jobs to complete
+  wait
+  echo "Resource cleanup complete in namespace: $NAMESPACE"
 }
 
 # Final cleanup
@@ -373,11 +398,10 @@ run_step "Resource Cleanup" resource_cleanup
 run_step "Cleanup PVCs" cleanup_pvcs
 run_step "Delete Catalog Source" delete_catalog_source
 run_step "Delete Kafka Resources" delete_kafka_resources
-run_step "Delete Custom Resources" delete_custom_resources
 run_step "Delete CAS CRDs Only" delete_cas_crd_instances
 run_step "Final Resource Cleanup" final_cleanup
-run_step "Uninstall Operators" uninstall_operators
 run_step "Delete Fusion Service Instance" delete_fusion_service_instance
+run_step "Uninstall Operators" uninstall_operators
 run_step "Delete Namespace" delete_namespace
 
 echo ""


### PR DESCRIPTION
output:

```
kumar@Kumars-Laptop CAS % sh customer_cas_cleanup.sh 
============================================================
CAS Cleanup Script - Customer-Safe Version
Target Namespace: ibm-cas
Preserve cluster-parade Pods/PVCs: false
Preserve Namespace: false
============================================================

This script will perform the following operations:
- Uninstall CAS operator and related CRs in 'ibm-cas'
- Delete KafkaTopics, KafkaUsers, Kafka brokers (without force)
- Delete PVCs and their associated PVs (unless marked keep)
- Remove CAS catalog sources, CRDs (except shared/global ones)
- Optionally delete the entire namespace unless --keep-namespace is specified

Are you sure you want to proceed? (y/n): y
Current Pods in namespace:
NAME                                                              READY   STATUS      RESTARTS   AGE
587b95e45a0a06f29b61147683b8167a2280880bd1b9ac82f77bc05cedlns8p   0/1     Completed   0          4h6m
amq-streams-cluster-operator-v2.9.1-1-7f6798f866-fffz6            1/1     Running     0          4h6m
cast-catalog-redstack-kdqcn                                       1/1     Running     0          4h7m
cluster-parade-1                                                  1/1     Running     0          4h5m
cluster-parade-2                                                  1/1     Running     0          4h5m
cluster-parade-3                                                  1/1     Running     0          4h3m
cnpg-controller-manager-86664c4b59-g6gtg                          1/1     Running     0          4h6m
docling-76d64dd7bc-bthhm                                          2/2     Running     0          4h6m
ibm-isf-cas-operator-controller-manager-6467778798-65qzl          2/2     Running     0          3h57m
kafka-entity-operator-6d559fcc4d-zbr2p                            2/2     Running     0          3h59m
kafka-kafka-0                                                     1/1     Running     0          3h59m
kafka-kafka-1                                                     1/1     Running     0          3h59m
kafka-kafka-2                                                     1/1     Running     0          3h59m
kafka-kafka-exporter-6d49496cc8-rg88f                             1/1     Running     0          3h58m
kafka-zookeeper-0                                                 1/1     Running     0          4h
kafka-zookeeper-1                                                 1/1     Running     0          4h
kafka-zookeeper-2                                                 1/1     Running     0          4h
pooler-parade-rw-6f488f6b8d-bp7vw                                 1/1     Running     0          4h1m
pooler-parade-rw-6f488f6b8d-jwzxt                                 1/1     Running     0          4h1m
qa-domain-test-rocky-64dc496477-wjfl8                             1/1     Running     0          3h32m
query-search-6d69998dbf-74b8d                                     1/1     Running     0          4h1m
query-search-6d69998dbf-l7wk8                                     1/1     Running     0          4h1m
query-search-6d69998dbf-v8442                                     1/1     Running     0          4h1m
vllm-embedding-8485646fcd-khhhs                                   2/2     Running     0          4h6m
vllm-vision-847b798767-qxtvd                                      2/2     Running     0          4h6m

Current PVCs in namespace:
NAME                             STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS          VOLUMEATTRIBUTESCLASS   AGE
cas-5-310e000a688296a7-1b5e4c9   Bound    cas-5-310e000a688296a7-1b5e4c9             1Gi        ROX            ibm-spectrum-fusion   <unset>                 3h32m
cluster-parade-1                 Bound    pvc-8d622673-2d38-4014-a935-3796441616ec   100Gi      RWO            ibm-spectrum-fusion   <unset>                 4h6m
cluster-parade-1-wal             Bound    pvc-fd2339a3-dd66-4fcb-91f3-760911bbe985   20Gi       RWO            ibm-spectrum-fusion   <unset>                 4h6m
cluster-parade-2                 Bound    pvc-9430bade-7eb0-4f01-b0e9-cdeba71e55ea   100Gi      RWO            ibm-spectrum-fusion   <unset>                 4h5m
cluster-parade-2-wal             Bound    pvc-14aa3368-8ee6-4b63-b5e5-fd631b24c40b   20Gi       RWO            ibm-spectrum-fusion   <unset>                 4h5m
cluster-parade-3                 Bound    pvc-235cba9c-29f9-4c79-afc1-f414ef7f0a0b   100Gi      RWO            ibm-spectrum-fusion   <unset>                 4h4m
cluster-parade-3-wal             Bound    pvc-386d9566-fbcd-4d09-8f48-2349d6cdfc7a   20Gi       RWO            ibm-spectrum-fusion   <unset>                 4h4m
data-kafka-kafka-0               Bound    pvc-1fdc1276-90f0-47cf-a079-bc27432a82fa   60Gi       RWO            ibm-spectrum-fusion   <unset>                 3h59m
data-kafka-kafka-1               Bound    pvc-bef34873-e71d-4a79-b0fc-12a4aa9ce9f6   60Gi       RWO            ibm-spectrum-fusion   <unset>                 3h59m
data-kafka-kafka-2               Bound    pvc-39ea4939-69c0-4e5a-ba57-1db9674b2a78   60Gi       RWO            ibm-spectrum-fusion   <unset>                 3h59m
data-kafka-zookeeper-0           Bound    pvc-fb0c9e26-1ea3-417b-9326-366961b46118   10Gi       RWO            ibm-spectrum-fusion   <unset>                 4h
data-kafka-zookeeper-1           Bound    pvc-840af368-da83-4aed-974a-598ef9c8e9fc   10Gi       RWO            ibm-spectrum-fusion   <unset>                 4h
data-kafka-zookeeper-2           Bound    pvc-208c8a49-f0c2-4fd3-822d-f6a52dc662f7   10Gi       RWO            ibm-spectrum-fusion   <unset>                 4h
qa-domain-test-rocky             Bound    pvc-ccdade32-7238-40ed-9889-a2c7bc78de23   1Gi        RWX            ibm-spectrum-fusion   <unset>                 3h32m
vllm-embedding-pvc               Bound    pvc-cefe8b87-881f-4f03-9e8e-d613013831d6   50Gi       RWX            ibm-spectrum-fusion   <unset>                 4h6m
vllm-vision-pvc                  Bound    pvc-5e4fd5a4-8f8f-4451-ba79-33879fb38829   50Gi       RWX            ibm-spectrum-fusion   <unset>                 4h6m

============================================================
INFO Starting: Resource Cleanup
============================================================

Cleaning up all resources in namespace: ibm-cas...
pod "amq-streams-cluster-operator-v2.9.1-1-7f6798f866-fffz6" deleted
pod "cast-catalog-redstack-kdqcn" deleted
pod "cluster-parade-1" deleted
pod "cluster-parade-2" deleted
pod "cluster-parade-3" deleted
pod "cnpg-controller-manager-86664c4b59-g6gtg" deleted
pod "docling-76d64dd7bc-bthhm" deleted
pod "ibm-isf-cas-operator-controller-manager-6467778798-65qzl" deleted
pod "kafka-entity-operator-6d559fcc4d-zbr2p" deleted
pod "kafka-kafka-0" deleted
pod "kafka-kafka-1" deleted
pod "kafka-kafka-2" deleted
pod "kafka-kafka-exporter-6d49496cc8-rg88f" deleted
pod "kafka-zookeeper-0" deleted
pod "kafka-zookeeper-1" deleted
pod "kafka-zookeeper-2" deleted
pod "pooler-parade-rw-6f488f6b8d-bp7vw" deleted
pod "pooler-parade-rw-6f488f6b8d-jwzxt" deleted
pod "qa-domain-test-rocky-64dc496477-wjfl8" deleted
pod "query-search-6d69998dbf-74b8d" deleted
pod "query-search-6d69998dbf-l7wk8" deleted
pod "query-search-6d69998dbf-v8442" deleted
pod "vllm-embedding-8485646fcd-khhhs" deleted
pod "vllm-vision-847b798767-qxtvd" deleted
secret "builder-dockercfg-n4ctl" deleted
secret "cas-user" deleted
secret "cast-catalog-redstack-dockercfg-8rrps" deleted
secret "cluster-parade-app" deleted
secret "cluster-parade-ca" deleted
secret "cluster-parade-dockercfg-7fkd4" deleted
secret "cluster-parade-pooler" deleted
secret "cluster-parade-replication" deleted
secret "cluster-parade-server" deleted
secret "cnpg-controller-manager-service-cert" deleted
secret "cnpg-manager-dockercfg-jmjsj" deleted
secret "default-dockercfg-x52gn" deleted
secret "deployer-dockercfg-89h7k" deleted
secret "docling" deleted
secret "ibm-isf-cas-operator-controller-manager-dockercfg-pwztd" deleted
secret "ibm-isf-cas-operator-system-dockercfg-dbvqc" deleted
secret "kafka-clients-ca" deleted
secret "kafka-clients-ca-cert" deleted
secret "kafka-cluster-ca" deleted
secret "kafka-cluster-ca-cert" deleted
secret "kafka-cluster-operator-certs" deleted
secret "kafka-entity-operator-dockercfg-g2zlh" deleted
secret "kafka-entity-topic-operator-certs" deleted
secret "kafka-entity-user-operator-certs" deleted
secret "kafka-kafka-brokers" deleted
secret "kafka-kafka-dockercfg-5vwmc" deleted
secret "kafka-kafka-exporter-certs" deleted
secret "kafka-kafka-exporter-dockercfg-vt8s8" deleted
secret "kafka-zookeeper-dockercfg-gh5mf" deleted
secret "kafka-zookeeper-nodes" deleted
secret "pooler-parade-rw-dockercfg-mhk6h" deleted
secret "qa-domain-test-rocky" deleted
secret "qa-domain-test-rocky-auth" deleted
secret "query-search" deleted
secret "strimzi-cluster-operator-dockercfg-mnmsv" deleted
secret "vllm-embedding" deleted
secret "vllm-vision" deleted
configmap "587b95e45a0a06f29b61147683b8167a2280880bd1b9ac82f77bc05cedfaaea" deleted
configmap "cnpg-default-monitoring" deleted
configmap "fusion-config" deleted
configmap "fusion-config-redstack" deleted
configmap "kafka-entity-topic-operator-config" deleted
configmap "kafka-entity-user-operator-config" deleted
configmap "kafka-kafka-0" deleted
configmap "kafka-kafka-1" deleted
configmap "kafka-kafka-2" deleted
configmap "kafka-zookeeper-config" deleted
configmap "kube-root-ca.crt" deleted
configmap "openshift-service-ca.crt" deleted
configmap "operator-config" deleted
configmap "qa-domain-test-rocky" deleted
configmap "query-search-config" deleted
configmap "strimzi-cluster-operator" deleted
domain.cas.isf.ibm.com "qa-domain-test-rocky" deleted
datasource.cas.isf.ibm.com "qa-domain-test-rocky" deleted
Resource cleanup complete in namespace: ibm-cas

============================================================
INFO Completed: Resource Cleanup
============================================================

============================================================
INFO Starting: Cleanup PVCs
============================================================

Starting PVC cleanup in namespace: ibm-cas
Deleting PVC: cas-5-310e000a688296a7-1b5e4c9
Deleting PVC: cluster-parade-1
Deleting PVC: cluster-parade-1-wal
Deleting PVC: cluster-parade-2
Deleting PVC: cluster-parade-2-wal
persistentvolumeclaim "cas-5-310e000a688296a7-1b5e4c9" deleted
persistentvolumeclaim "cluster-parade-1" deleted
persistentvolumeclaim "cluster-parade-1-wal" deleted
persistentvolumeclaim "cluster-parade-2-wal" deleted
persistentvolumeclaim "cluster-parade-2" deleted
[1/5] Waiting for pvc/cas-5-310e000a688296a7-1b5e4c9 to terminate...
[1/5] Waiting for pvc/cluster-parade-1 to terminate...
[1/5] Waiting for pvc/cluster-parade-2 to terminate...
[1/5] Waiting for pvc/cluster-parade-2-wal to terminate...
[1/5] Waiting for pvc/cluster-parade-1-wal to terminate...
[2/5] Waiting for pvc/cas-5-310e000a688296a7-1b5e4c9 to terminate...
[2/5] Waiting for pvc/cluster-parade-1 to terminate...
[2/5] Waiting for pvc/cluster-parade-2-wal to terminate...
[2/5] Waiting for pvc/cluster-parade-2 to terminate...
[2/5] Waiting for pvc/cluster-parade-1-wal to terminate...
[3/5] Waiting for pvc/cluster-parade-1 to terminate...
[3/5] Waiting for pvc/cas-5-310e000a688296a7-1b5e4c9 to terminate...
[3/5] Waiting for pvc/cluster-parade-2-wal to terminate...
[3/5] Waiting for pvc/cluster-parade-2 to terminate...
[3/5] Waiting for pvc/cluster-parade-1-wal to terminate...
[4/5] Waiting for pvc/cluster-parade-1 to terminate...
[4/5] Waiting for pvc/cas-5-310e000a688296a7-1b5e4c9 to terminate...
[4/5] Waiting for pvc/cluster-parade-2-wal to terminate...
[4/5] Waiting for pvc/cluster-parade-2 to terminate...
[4/5] Waiting for pvc/cluster-parade-1-wal to terminate...
[5/5] Waiting for pvc/cluster-parade-2-wal to terminate...
[5/5] Waiting for pvc/cas-5-310e000a688296a7-1b5e4c9 to terminate...
[5/5] Waiting for pvc/cluster-parade-1 to terminate...
[5/5] Waiting for pvc/cluster-parade-2 to terminate...
[5/5] Waiting for pvc/cluster-parade-1-wal to terminate...
pvc/cluster-parade-2-wal did not delete after 5 retries.
pvc/cas-5-310e000a688296a7-1b5e4c9 did not delete after 5 retries.
pvc/cluster-parade-1 did not delete after 5 retries.
pvc/cluster-parade-2 did not delete after 5 retries.
pvc/cluster-parade-1-wal did not delete after 5 retries.
Processing PV pvc-14aa3368-8ee6-4b63-b5e5-fd631b24c40b
pvc-eadaf86b-5eef-4527-b0a5-3115247acd4e linked to PVC cluster-parade-2-wal
Processing PV cas-5-310e000a688296a7-1b5e4c9 linked to PVC cas-5-310e000a688296a7-1b5e4c9
Processing PV pvc-8d622673-2d38-4014-a935-3796441616ec
pvc-dcceebc9-7219-40f6-af84-6bd795ad0db4
pvc-e0860118-8ba1-4d8e-b948-cbad23b54fe0
pvc-fd2339a3-dd66-4fcb-91f3-760911bbe985 linked to PVC cluster-parade-1
Processing PV pvc-14aa3368-8ee6-4b63-b5e5-fd631b24c40b
pvc-9430bade-7eb0-4f01-b0e9-cdeba71e55ea
pvc-be4a6797-b2e6-4f9e-9a23-99e6cca249f7
pvc-eadaf86b-5eef-4527-b0a5-3115247acd4e linked to PVC cluster-parade-2
Processing PV pvc-e0860118-8ba1-4d8e-b948-cbad23b54fe0
pvc-fd2339a3-dd66-4fcb-91f3-760911bbe985 linked to PVC cluster-parade-1-wal
PV cas-5-310e000a688296a7-1b5e4c9 status is Bound
Deleting PV cas-5-310e000a688296a7-1b5e4c9
Error from server (NotFound): persistentvolumes "pvc-8d622673-2d38-4014-a935-3796441616ec\npvc-dcceebc9-7219-40f6-af84-6bd795ad0db4\npvc-e0860118-8ba1-4d8e-b948-cbad23b54fe0\npvc-fd2339a3-dd66-4fcb-91f3-760911bbe985" not found
PV pvc-8d622673-2d38-4014-a935-3796441616ec
pvc-dcceebc9-7219-40f6-af84-6bd795ad0db4
pvc-e0860118-8ba1-4d8e-b948-cbad23b54fe0
pvc-fd2339a3-dd66-4fcb-91f3-760911bbe985 status is 
Deleting PV pvc-8d622673-2d38-4014-a935-3796441616ec
pvc-dcceebc9-7219-40f6-af84-6bd795ad0db4
pvc-e0860118-8ba1-4d8e-b948-cbad23b54fe0
pvc-fd2339a3-dd66-4fcb-91f3-760911bbe985
Error from server (NotFound): persistentvolumes "pvc-14aa3368-8ee6-4b63-b5e5-fd631b24c40b\npvc-9430bade-7eb0-4f01-b0e9-cdeba71e55ea\npvc-be4a6797-b2e6-4f9e-9a23-99e6cca249f7\npvc-eadaf86b-5eef-4527-b0a5-3115247acd4e" not found
PV pvc-14aa3368-8ee6-4b63-b5e5-fd631b24c40b
pvc-9430bade-7eb0-4f01-b0e9-cdeba71e55ea
pvc-be4a6797-b2e6-4f9e-9a23-99e6cca249f7
pvc-eadaf86b-5eef-4527-b0a5-3115247acd4e status is 
Deleting PV pvc-14aa3368-8ee6-4b63-b5e5-fd631b24c40b
pvc-9430bade-7eb0-4f01-b0e9-cdeba71e55ea
pvc-be4a6797-b2e6-4f9e-9a23-99e6cca249f7
pvc-eadaf86b-5eef-4527-b0a5-3115247acd4e
Error from server (NotFound): persistentvolumes "pvc-14aa3368-8ee6-4b63-b5e5-fd631b24c40b\npvc-eadaf86b-5eef-4527-b0a5-3115247acd4e" not found
PV pvc-14aa3368-8ee6-4b63-b5e5-fd631b24c40b
pvc-eadaf86b-5eef-4527-b0a5-3115247acd4e status is 
Deleting PV pvc-14aa3368-8ee6-4b63-b5e5-fd631b24c40b
pvc-eadaf86b-5eef-4527-b0a5-3115247acd4e
persistentvolume "cas-5-310e000a688296a7-1b5e4c9" deleted
Error from server (NotFound): persistentvolumes "pvc-e0860118-8ba1-4d8e-b948-cbad23b54fe0\npvc-fd2339a3-dd66-4fcb-91f3-760911bbe985" not found
PV pvc-e0860118-8ba1-4d8e-b948-cbad23b54fe0
pvc-fd2339a3-dd66-4fcb-91f3-760911bbe985 status is 
Deleting PV pvc-e0860118-8ba1-4d8e-b948-cbad23b54fe0
pvc-fd2339a3-dd66-4fcb-91f3-760911bbe985
Error from server (NotFound): persistentvolumes "pvc-14aa3368-8ee6-4b63-b5e5-fd631b24c40b\npvc-9430bade-7eb0-4f01-b0e9-cdeba71e55ea\npvc-be4a6797-b2e6-4f9e-9a23-99e6cca249f7\npvc-eadaf86b-5eef-4527-b0a5-3115247acd4e" not found
Error from server (NotFound): persistentvolumes "pvc-14aa3368-8ee6-4b63-b5e5-fd631b24c40b\npvc-eadaf86b-5eef-4527-b0a5-3115247acd4e" not found
[1/5] Waiting for pv/cas-5-310e000a688296a7-1b5e4c9 to terminate...
Error from server (NotFound): persistentvolumes "pvc-e0860118-8ba1-4d8e-b948-cbad23b54fe0\npvc-fd2339a3-dd66-4fcb-91f3-760911bbe985" not found
pv/pvc-14aa3368-8ee6-4b63-b5e5-fd631b24c40b
pvc-9430bade-7eb0-4f01-b0e9-cdeba71e55ea
pvc-be4a6797-b2e6-4f9e-9a23-99e6cca249f7
pvc-eadaf86b-5eef-4527-b0a5-3115247acd4e deleted successfully.
Error from server (NotFound): persistentvolumes "pvc-8d622673-2d38-4014-a935-3796441616ec\npvc-dcceebc9-7219-40f6-af84-6bd795ad0db4\npvc-e0860118-8ba1-4d8e-b948-cbad23b54fe0\npvc-fd2339a3-dd66-4fcb-91f3-760911bbe985" not found
pv/pvc-14aa3368-8ee6-4b63-b5e5-fd631b24c40b
pvc-eadaf86b-5eef-4527-b0a5-3115247acd4e deleted successfully.
Deleting PVC: cluster-parade-3
Deleting PVC: cluster-parade-3-wal
pv/pvc-e0860118-8ba1-4d8e-b948-cbad23b54fe0
pvc-fd2339a3-dd66-4fcb-91f3-760911bbe985 deleted successfully.
pv/pvc-8d622673-2d38-4014-a935-3796441616ec
pvc-dcceebc9-7219-40f6-af84-6bd795ad0db4
pvc-e0860118-8ba1-4d8e-b948-cbad23b54fe0
pvc-fd2339a3-dd66-4fcb-91f3-760911bbe985 deleted successfully.
Deleting PVC: data-kafka-kafka-0
Deleting PVC: data-kafka-kafka-1
persistentvolumeclaim "cluster-parade-3-wal" deleted
persistentvolumeclaim "cluster-parade-3" deleted
persistentvolumeclaim "data-kafka-kafka-0" deleted
[1/5] Waiting for pvc/cluster-parade-3-wal to terminate...
[1/5] Waiting for pvc/cluster-parade-3 to terminate...
persistentvolumeclaim "data-kafka-kafka-1" deleted
[1/5] Waiting for pvc/data-kafka-kafka-0 to terminate...
[1/5] Waiting for pvc/data-kafka-kafka-1 to terminate...
[2/5] Waiting for pv/cas-5-310e000a688296a7-1b5e4c9 to terminate...
[2/5] Waiting for pvc/cluster-parade-3-wal to terminate...
[2/5] Waiting for pvc/cluster-parade-3 to terminate...
[2/5] Waiting for pvc/data-kafka-kafka-0 to terminate...
[2/5] Waiting for pvc/data-kafka-kafka-1 to terminate...
[3/5] Waiting for pv/cas-5-310e000a688296a7-1b5e4c9 to terminate...
[3/5] Waiting for pvc/cluster-parade-3-wal to terminate...
[3/5] Waiting for pvc/cluster-parade-3 to terminate...
[3/5] Waiting for pvc/data-kafka-kafka-0 to terminate...
[3/5] Waiting for pvc/data-kafka-kafka-1 to terminate...
[4/5] Waiting for pv/cas-5-310e000a688296a7-1b5e4c9 to terminate...
[4/5] Waiting for pvc/cluster-parade-3-wal to terminate...
[4/5] Waiting for pvc/cluster-parade-3 to terminate...
[4/5] Waiting for pvc/data-kafka-kafka-0 to terminate...
[4/5] Waiting for pvc/data-kafka-kafka-1 to terminate...
[5/5] Waiting for pv/cas-5-310e000a688296a7-1b5e4c9 to terminate...
[5/5] Waiting for pvc/cluster-parade-3-wal to terminate...
[5/5] Waiting for pvc/cluster-parade-3 to terminate...
[5/5] Waiting for pvc/data-kafka-kafka-0 to terminate...
[5/5] Waiting for pvc/data-kafka-kafka-1 to terminate...
pv/cas-5-310e000a688296a7-1b5e4c9 did not delete after 5 retries.
Deleting PVC: data-kafka-kafka-2
persistentvolumeclaim "data-kafka-kafka-2" deleted
pvc/cluster-parade-3-wal did not delete after 5 retries.
pvc/cluster-parade-3 did not delete after 5 retries.
[1/5] Waiting for pvc/data-kafka-kafka-2 to terminate...
pvc/data-kafka-kafka-0 did not delete after 5 retries.
Processing PV pvc-235cba9c-29f9-4c79-afc1-f414ef7f0a0b
pvc-386d9566-fbcd-4d09-8f48-2349d6cdfc7a linked to PVC cluster-parade-3
Processing PV pvc-386d9566-fbcd-4d09-8f48-2349d6cdfc7a linked to PVC cluster-parade-3-wal
pvc/data-kafka-kafka-1 did not delete after 5 retries.
Error from server (NotFound): persistentvolumes "pvc-235cba9c-29f9-4c79-afc1-f414ef7f0a0b\npvc-386d9566-fbcd-4d09-8f48-2349d6cdfc7a" not found
PV pvc-235cba9c-29f9-4c79-afc1-f414ef7f0a0b
pvc-386d9566-fbcd-4d09-8f48-2349d6cdfc7a status is 
Deleting PV pvc-235cba9c-29f9-4c79-afc1-f414ef7f0a0b
pvc-386d9566-fbcd-4d09-8f48-2349d6cdfc7a
PV pvc-386d9566-fbcd-4d09-8f48-2349d6cdfc7a status is Bound
Deleting PV pvc-386d9566-fbcd-4d09-8f48-2349d6cdfc7a
Processing PV pvc-1fdc1276-90f0-47cf-a079-bc27432a82fa
pvc-80235221-06d7-45e7-ab4b-851b614018b6 linked to PVC data-kafka-kafka-0
Error from server (NotFound): persistentvolumes "pvc-235cba9c-29f9-4c79-afc1-f414ef7f0a0b\npvc-386d9566-fbcd-4d09-8f48-2349d6cdfc7a" not found
persistentvolume "pvc-386d9566-fbcd-4d09-8f48-2349d6cdfc7a" deleted
Processing PV pvc-bef34873-e71d-4a79-b0fc-12a4aa9ce9f6 linked to PVC data-kafka-kafka-1
Error from server (NotFound): persistentvolumes "pvc-1fdc1276-90f0-47cf-a079-bc27432a82fa\npvc-80235221-06d7-45e7-ab4b-851b614018b6" not found
PV pvc-1fdc1276-90f0-47cf-a079-bc27432a82fa
pvc-80235221-06d7-45e7-ab4b-851b614018b6 status is 
Deleting PV pvc-1fdc1276-90f0-47cf-a079-bc27432a82fa
pvc-80235221-06d7-45e7-ab4b-851b614018b6
pv/pvc-235cba9c-29f9-4c79-afc1-f414ef7f0a0b
pvc-386d9566-fbcd-4d09-8f48-2349d6cdfc7a deleted successfully.
[1/5] Waiting for pv/pvc-386d9566-fbcd-4d09-8f48-2349d6cdfc7a to terminate...
PV pvc-bef34873-e71d-4a79-b0fc-12a4aa9ce9f6 status is Bound
Deleting PV pvc-bef34873-e71d-4a79-b0fc-12a4aa9ce9f6
Error from server (NotFound): persistentvolumes "pvc-1fdc1276-90f0-47cf-a079-bc27432a82fa\npvc-80235221-06d7-45e7-ab4b-851b614018b6" not found
Deleting PVC: data-kafka-zookeeper-0
pv/pvc-1fdc1276-90f0-47cf-a079-bc27432a82fa
pvc-80235221-06d7-45e7-ab4b-851b614018b6 deleted successfully.
persistentvolume "pvc-bef34873-e71d-4a79-b0fc-12a4aa9ce9f6" deleted
Deleting PVC: data-kafka-zookeeper-1
persistentvolumeclaim "data-kafka-zookeeper-0" deleted
[1/5] Waiting for pv/pvc-bef34873-e71d-4a79-b0fc-12a4aa9ce9f6 to terminate...
[1/5] Waiting for pvc/data-kafka-zookeeper-0 to terminate...
persistentvolumeclaim "data-kafka-zookeeper-1" deleted
[1/5] Waiting for pvc/data-kafka-zookeeper-1 to terminate...
[2/5] Waiting for pvc/data-kafka-kafka-2 to terminate...
[2/5] Waiting for pv/pvc-386d9566-fbcd-4d09-8f48-2349d6cdfc7a to terminate...
[2/5] Waiting for pv/pvc-bef34873-e71d-4a79-b0fc-12a4aa9ce9f6 to terminate...
[2/5] Waiting for pvc/data-kafka-zookeeper-0 to terminate...
[2/5] Waiting for pvc/data-kafka-zookeeper-1 to terminate...
[3/5] Waiting for pvc/data-kafka-kafka-2 to terminate...
[3/5] Waiting for pv/pvc-386d9566-fbcd-4d09-8f48-2349d6cdfc7a to terminate...
[3/5] Waiting for pv/pvc-bef34873-e71d-4a79-b0fc-12a4aa9ce9f6 to terminate...
[3/5] Waiting for pvc/data-kafka-zookeeper-0 to terminate...
[3/5] Waiting for pvc/data-kafka-zookeeper-1 to terminate...
[4/5] Waiting for pvc/data-kafka-kafka-2 to terminate...
[4/5] Waiting for pv/pvc-386d9566-fbcd-4d09-8f48-2349d6cdfc7a to terminate...
[4/5] Waiting for pvc/data-kafka-zookeeper-0 to terminate...
[4/5] Waiting for pv/pvc-bef34873-e71d-4a79-b0fc-12a4aa9ce9f6 to terminate...
[4/5] Waiting for pvc/data-kafka-zookeeper-1 to terminate...
[5/5] Waiting for pvc/data-kafka-kafka-2 to terminate...
[5/5] Waiting for pv/pvc-386d9566-fbcd-4d09-8f48-2349d6cdfc7a to terminate...
[5/5] Waiting for pv/pvc-bef34873-e71d-4a79-b0fc-12a4aa9ce9f6 to terminate...
[5/5] Waiting for pvc/data-kafka-zookeeper-0 to terminate...
[5/5] Waiting for pvc/data-kafka-zookeeper-1 to terminate...
pvc/data-kafka-kafka-2 did not delete after 5 retries.
Processing PV pvc-39ea4939-69c0-4e5a-ba57-1db9674b2a78 linked to PVC data-kafka-kafka-2
PV pvc-39ea4939-69c0-4e5a-ba57-1db9674b2a78 status is Bound
Deleting PV pvc-39ea4939-69c0-4e5a-ba57-1db9674b2a78
persistentvolume "pvc-39ea4939-69c0-4e5a-ba57-1db9674b2a78" deleted
[1/5] Waiting for pv/pvc-39ea4939-69c0-4e5a-ba57-1db9674b2a78 to terminate...
pv/pvc-386d9566-fbcd-4d09-8f48-2349d6cdfc7a did not delete after 5 retries.
Deleting PVC: data-kafka-zookeeper-2
persistentvolumeclaim "data-kafka-zookeeper-2" deleted
pv/pvc-bef34873-e71d-4a79-b0fc-12a4aa9ce9f6 did not delete after 5 retries.
pvc/data-kafka-zookeeper-0 did not delete after 5 retries.
Deleting PVC: qa-domain-test-rocky
[1/5] Waiting for pvc/data-kafka-zookeeper-2 to terminate...
persistentvolumeclaim "qa-domain-test-rocky" deleted
pvc/data-kafka-zookeeper-1 did not delete after 5 retries.
Processing PV pvc-a16dfeb5-a726-4df3-93a2-25a78f4cd834
pvc-fb0c9e26-1ea3-417b-9326-366961b46118 linked to PVC data-kafka-zookeeper-0
[1/5] Waiting for pvc/qa-domain-test-rocky to terminate...
Error from server (NotFound): persistentvolumes "pvc-a16dfeb5-a726-4df3-93a2-25a78f4cd834\npvc-fb0c9e26-1ea3-417b-9326-366961b46118" not found
PV pvc-a16dfeb5-a726-4df3-93a2-25a78f4cd834
pvc-fb0c9e26-1ea3-417b-9326-366961b46118 status is 
Deleting PV pvc-a16dfeb5-a726-4df3-93a2-25a78f4cd834
pvc-fb0c9e26-1ea3-417b-9326-366961b46118
Processing PV pvc-840af368-da83-4aed-974a-598ef9c8e9fc linked to PVC data-kafka-zookeeper-1
Error from server (NotFound): persistentvolumes "pvc-a16dfeb5-a726-4df3-93a2-25a78f4cd834\npvc-fb0c9e26-1ea3-417b-9326-366961b46118" not found
PV pvc-840af368-da83-4aed-974a-598ef9c8e9fc status is Bound
Deleting PV pvc-840af368-da83-4aed-974a-598ef9c8e9fc
pv/pvc-a16dfeb5-a726-4df3-93a2-25a78f4cd834
pvc-fb0c9e26-1ea3-417b-9326-366961b46118 deleted successfully.
Deleting PVC: vllm-embedding-pvc
persistentvolume "pvc-840af368-da83-4aed-974a-598ef9c8e9fc" deleted
persistentvolumeclaim "vllm-embedding-pvc" deleted
[1/5] Waiting for pv/pvc-840af368-da83-4aed-974a-598ef9c8e9fc to terminate...
[1/5] Waiting for pvc/vllm-embedding-pvc to terminate...
[2/5] Waiting for pv/pvc-39ea4939-69c0-4e5a-ba57-1db9674b2a78 to terminate...
[2/5] Waiting for pvc/data-kafka-zookeeper-2 to terminate...
[2/5] Waiting for pvc/qa-domain-test-rocky to terminate...
[2/5] Waiting for pv/pvc-840af368-da83-4aed-974a-598ef9c8e9fc to terminate...
[2/5] Waiting for pvc/vllm-embedding-pvc to terminate...
[3/5] Waiting for pv/pvc-39ea4939-69c0-4e5a-ba57-1db9674b2a78 to terminate...
[3/5] Waiting for pvc/data-kafka-zookeeper-2 to terminate...
[3/5] Waiting for pvc/qa-domain-test-rocky to terminate...
[3/5] Waiting for pv/pvc-840af368-da83-4aed-974a-598ef9c8e9fc to terminate...
[3/5] Waiting for pvc/vllm-embedding-pvc to terminate...
[4/5] Waiting for pv/pvc-39ea4939-69c0-4e5a-ba57-1db9674b2a78 to terminate...
[4/5] Waiting for pvc/data-kafka-zookeeper-2 to terminate...
[4/5] Waiting for pvc/qa-domain-test-rocky to terminate...
[4/5] Waiting for pv/pvc-840af368-da83-4aed-974a-598ef9c8e9fc to terminate...
[4/5] Waiting for pvc/vllm-embedding-pvc to terminate...
[5/5] Waiting for pv/pvc-39ea4939-69c0-4e5a-ba57-1db9674b2a78 to terminate...
[5/5] Waiting for pvc/data-kafka-zookeeper-2 to terminate...
[5/5] Waiting for pvc/qa-domain-test-rocky to terminate...
[5/5] Waiting for pv/pvc-840af368-da83-4aed-974a-598ef9c8e9fc to terminate...
pv/pvc-39ea4939-69c0-4e5a-ba57-1db9674b2a78 did not delete after 5 retries.
[5/5] Waiting for pvc/vllm-embedding-pvc to terminate...
Deleting PVC: vllm-vision-pvc
persistentvolumeclaim "vllm-vision-pvc" deleted
[1/5] Waiting for pvc/vllm-vision-pvc to terminate...
pvc/data-kafka-zookeeper-2 did not delete after 5 retries.
Processing PV pvc-208c8a49-f0c2-4fd3-822d-f6a52dc662f7 linked to PVC data-kafka-zookeeper-2
PV pvc-208c8a49-f0c2-4fd3-822d-f6a52dc662f7 status is Bound
Deleting PV pvc-208c8a49-f0c2-4fd3-822d-f6a52dc662f7
pvc/qa-domain-test-rocky did not delete after 5 retries.
persistentvolume "pvc-208c8a49-f0c2-4fd3-822d-f6a52dc662f7" deleted
Processing PV pvc-ccdade32-7238-40ed-9889-a2c7bc78de23 linked to PVC qa-domain-test-rocky
[1/5] Waiting for pv/pvc-208c8a49-f0c2-4fd3-822d-f6a52dc662f7 to terminate...
PV pvc-ccdade32-7238-40ed-9889-a2c7bc78de23 status is Bound
Deleting PV pvc-ccdade32-7238-40ed-9889-a2c7bc78de23
pv/pvc-840af368-da83-4aed-974a-598ef9c8e9fc did not delete after 5 retries.
pvc/vllm-embedding-pvc did not delete after 5 retries.
persistentvolume "pvc-ccdade32-7238-40ed-9889-a2c7bc78de23" deleted
[1/5] Waiting for pv/pvc-ccdade32-7238-40ed-9889-a2c7bc78de23 to terminate...
Processing PV pvc-64f5e563-6c31-4b00-b70e-1edefaf21128
pvc-cefe8b87-881f-4f03-9e8e-d613013831d6 linked to PVC vllm-embedding-pvc
Error from server (NotFound): persistentvolumes "pvc-64f5e563-6c31-4b00-b70e-1edefaf21128\npvc-cefe8b87-881f-4f03-9e8e-d613013831d6" not found
PV pvc-64f5e563-6c31-4b00-b70e-1edefaf21128
pvc-cefe8b87-881f-4f03-9e8e-d613013831d6 status is 
Deleting PV pvc-64f5e563-6c31-4b00-b70e-1edefaf21128
pvc-cefe8b87-881f-4f03-9e8e-d613013831d6
[2/5] Waiting for pvc/vllm-vision-pvc to terminate...
Error from server (NotFound): persistentvolumes "pvc-64f5e563-6c31-4b00-b70e-1edefaf21128\npvc-cefe8b87-881f-4f03-9e8e-d613013831d6" not found
pv/pvc-64f5e563-6c31-4b00-b70e-1edefaf21128
pvc-cefe8b87-881f-4f03-9e8e-d613013831d6 deleted successfully.
[2/5] Waiting for pv/pvc-208c8a49-f0c2-4fd3-822d-f6a52dc662f7 to terminate...
[2/5] Waiting for pv/pvc-ccdade32-7238-40ed-9889-a2c7bc78de23 to terminate...
[3/5] Waiting for pvc/vllm-vision-pvc to terminate...
[3/5] Waiting for pv/pvc-208c8a49-f0c2-4fd3-822d-f6a52dc662f7 to terminate...
[3/5] Waiting for pv/pvc-ccdade32-7238-40ed-9889-a2c7bc78de23 to terminate...
[4/5] Waiting for pvc/vllm-vision-pvc to terminate...
[4/5] Waiting for pv/pvc-208c8a49-f0c2-4fd3-822d-f6a52dc662f7 to terminate...
[4/5] Waiting for pv/pvc-ccdade32-7238-40ed-9889-a2c7bc78de23 to terminate...
[5/5] Waiting for pvc/vllm-vision-pvc to terminate...
[5/5] Waiting for pv/pvc-208c8a49-f0c2-4fd3-822d-f6a52dc662f7 to terminate...
[5/5] Waiting for pv/pvc-ccdade32-7238-40ed-9889-a2c7bc78de23 to terminate...
pvc/vllm-vision-pvc did not delete after 5 retries.
Processing PV pvc-5e4fd5a4-8f8f-4451-ba79-33879fb38829 linked to PVC vllm-vision-pvc
PV pvc-5e4fd5a4-8f8f-4451-ba79-33879fb38829 status is Bound
Deleting PV pvc-5e4fd5a4-8f8f-4451-ba79-33879fb38829
pv/pvc-208c8a49-f0c2-4fd3-822d-f6a52dc662f7 did not delete after 5 retries.
persistentvolume "pvc-5e4fd5a4-8f8f-4451-ba79-33879fb38829" deleted
[1/5] Waiting for pv/pvc-5e4fd5a4-8f8f-4451-ba79-33879fb38829 to terminate...
pv/pvc-ccdade32-7238-40ed-9889-a2c7bc78de23 did not delete after 5 retries.
[2/5] Waiting for pv/pvc-5e4fd5a4-8f8f-4451-ba79-33879fb38829 to terminate...
[3/5] Waiting for pv/pvc-5e4fd5a4-8f8f-4451-ba79-33879fb38829 to terminate...
[4/5] Waiting for pv/pvc-5e4fd5a4-8f8f-4451-ba79-33879fb38829 to terminate...
[5/5] Waiting for pv/pvc-5e4fd5a4-8f8f-4451-ba79-33879fb38829 to terminate...
pv/pvc-5e4fd5a4-8f8f-4451-ba79-33879fb38829 did not delete after 5 retries.
PVC and PV cleanup complete in namespace: ibm-cas

============================================================
INFO Completed: Cleanup PVCs
============================================================

============================================================
INFO Starting: Delete Catalog Source
============================================================


============================================================
INFO Completed: Delete Catalog Source
============================================================

============================================================
INFO Starting: Delete Kafka Resources
============================================================

Deleting kafkatopic.kafka.strimzi.io/cas-status...
kafkatopic.kafka.strimzi.io "cas-status" deleted
kafkatopics.kafka.strimzi.io/cas-status deleted successfully.
Deleting kafkauser.kafka.strimzi.io/cas-user...
kafkauser.kafka.strimzi.io "cas-user" deleted
kafkauser.kafka.strimzi.io/cas-user deleted successfully.
Deleting kafka.kafka.strimzi.io/kafka...
kafka.kafka.strimzi.io "kafka" deleted
kafka.kafka.strimzi.io/kafka deleted successfully.

============================================================
INFO Completed: Delete Kafka Resources
============================================================

============================================================
INFO Starting: Delete CAS CRDs Only
============================================================

Looking for CAS-specific CRDs in namespace: ibm-cas (excluding Kafka CRDs)...
----
CRD: casinstalls.cas.isf.ibm.com
Resource: casinstalls
Checking instances in namespace: ibm-cas
  Deleting casinstalls/cas-install-redstack in namespace ibm-cas
casinstall.cas.isf.ibm.com/cas-install-redstack patched (no change)
casinstall.cas.isf.ibm.com "cas-install-redstack" deleted
casinstalls/cas-install-redstack deleted successfully.
----
CRD: casresourceaccesscontrols.cas.isf.ibm.com
Resource: casresourceaccesscontrols
Checking instances in namespace: ibm-cas
  No instances found for casresourceaccesscontrols in namespace ibm-cas
----
CRD: datasources.cas.isf.ibm.com
Resource: datasources
Checking instances in namespace: ibm-cas
  No instances found for datasources in namespace ibm-cas
----
CRD: documentprocessors.cas.isf.ibm.com
Resource: documentprocessors
Checking instances in namespace: ibm-cas
  Deleting documentprocessors/qa-domain-test-rocky in namespace ibm-cas
documentprocessor.cas.isf.ibm.com/qa-domain-test-rocky patched
documentprocessor.cas.isf.ibm.com/qa-domain-test-rocky patched
documentprocessor.cas.isf.ibm.com "qa-domain-test-rocky" deleted
documentprocessors/qa-domain-test-rocky deleted successfully.
----
CRD: domains.cas.isf.ibm.com
Resource: domains
Checking instances in namespace: ibm-cas
  No instances found for domains in namespace ibm-cas
----
CRD: identityproviders.cas.isf.ibm.com
Resource: identityproviders
Checking instances in namespace: ibm-cas
  No instances found for identityproviders in namespace ibm-cas

============================================================
INFO Completed: Delete CAS CRDs Only
============================================================

============================================================
INFO Starting: Final Resource Cleanup
============================================================

Cleaning up all resources in namespace: ibm-cas...
pod "amq-streams-cluster-operator-v2.9.1-1-7f6798f866-n6hrz" deleted
pod "cast-catalog-redstack-bdw5x" deleted
pod "cluster-parade-1" deleted
pod "cluster-parade-2" deleted
pod "cluster-parade-3" deleted
pod "cnpg-controller-manager-b98d55fb6-rh567" deleted
pod "ibm-isf-cas-operator-controller-manager-6467778798-26qhg" deleted
pod "pooler-parade-rw-6f488f6b8d-bnzbf" deleted
pod "pooler-parade-rw-6f488f6b8d-pxrlw" deleted
No resources found
secret "builder-dockercfg-n4ctl" deleted
secret "cast-catalog-redstack-dockercfg-8rrps" deleted
secret "cluster-parade-app" deleted
secret "cluster-parade-ca" deleted
secret "cluster-parade-dockercfg-7fkd4" deleted
secret "cluster-parade-pooler" deleted
secret "cluster-parade-replication" deleted
secret "cluster-parade-server" deleted
secret "cnpg-controller-manager-service-cert" deleted
secret "cnpg-manager-dockercfg-jmjsj" deleted
secret "default-dockercfg-x52gn" deleted
secret "deployer-dockercfg-89h7k" deleted
secret "ibm-isf-cas-operator-controller-manager-dockercfg-pwztd" deleted
secret "ibm-isf-cas-operator-system-dockercfg-dbvqc" deleted
secret "pooler-parade-rw-dockercfg-mhk6h" deleted
secret "qa-domain-test-rocky-auth" deleted
secret "strimzi-cluster-operator-dockercfg-mnmsv" deleted
configmap "fusion-config" deleted
configmap "kube-root-ca.crt" deleted
configmap "openshift-service-ca.crt" deleted
pod "amq-streams-cluster-operator-v2.9.1-1-7f6798f866-d4w2g" deleted
pod "cast-catalog-redstack-vkchv" deleted
pod "cnpg-controller-manager-79675c959-b98z8" deleted
pod "ibm-isf-cas-operator-controller-manager-6467778798-79gtf" deleted
pod "pooler-parade-rw-6f488f6b8d-s7k4k" deleted
pod "pooler-parade-rw-6f488f6b8d-zzwtp" deleted
service "cast-catalog-redstack" deleted
service "cluster-parade-r" deleted
service "cluster-parade-ro" deleted
service "cluster-parade-rw" deleted
service "cnpg-controller-manager-service" deleted
service "cnpg-webhook-service" deleted
service "ibm-isf-cas-operator-controller-manager-metrics-service" deleted
service "pooler-parade-rw" deleted
deployment.apps "amq-streams-cluster-operator-v2.9.1-1" deleted
deployment.apps "cnpg-controller-manager" deleted
deployment.apps "ibm-isf-cas-operator-controller-manager" deleted
deployment.apps "pooler-parade-rw" deleted
Warning: apps.openshift.io/v1 DeploymentConfig is deprecated in v4.14+, unavailable in v4.10000+
Resource cleanup complete in namespace: ibm-cas

============================================================
INFO Completed: Final Resource Cleanup
============================================================

============================================================
INFO Starting: Uninstall Operators
============================================================

Deleting subscription: subscription.operators.coreos.com/amq-streams-stable-redhat-operators-openshift-marketplace
subscription.operators.coreos.com "amq-streams-stable-redhat-operators-openshift-marketplace" deleted
Subscription/amq-streams-stable-redhat-operators-openshift-marketplace deleted successfully.
Deleting CSV: amqstreams.v2.9.1-1
clusterserviceversion.operators.coreos.com "amqstreams.v2.9.1-1" deleted
clusterserviceversion/amqstreams.v2.9.1-1 deleted successfully.
Deleting subscription: subscription.operators.coreos.com/cast-operator
subscription.operators.coreos.com "cast-operator" deleted
Subscription/cast-operator deleted successfully.
Deleting CSV: ibm-isf-cas-operator.v1.0.6-20250909204552
clusterserviceversion.operators.coreos.com "ibm-isf-cas-operator.v1.0.6-20250909204552" deleted
clusterserviceversion/ibm-isf-cas-operator.v1.0.6-20250909204552 deleted successfully.
Deleting subscription: subscription.operators.coreos.com/cloudnative-pg-stable-v1-certified-operators-openshift-marketplace
subscription.operators.coreos.com "cloudnative-pg-stable-v1-certified-operators-openshift-marketplace" deleted
Subscription/cloudnative-pg-stable-v1-certified-operators-openshift-marketplace deleted successfully.
Deleting CSV: cloudnative-pg.v1.26.1
clusterserviceversion.operators.coreos.com "cloudnative-pg.v1.26.1" deleted
[1/5] Waiting for clusterserviceversion/cloudnative-pg.v1.26.1 to terminate...
[2/5] Waiting for clusterserviceversion/cloudnative-pg.v1.26.1 to terminate...
clusterserviceversion/cloudnative-pg.v1.26.1 deleted successfully.

============================================================
INFO Completed: Uninstall Operators
============================================================

============================================================
INFO Starting: Delete Fusion Service Instance
============================================================

No FusionServiceInstance found in ibm-spectrum-fusion-ns.

=======.=====================================================
INFO Completed: Delete Fusion Service Instance
============================================================

============================================================
INFO Starting: Delete Namespace
============================================================

Deleting Namespace: ibm-cas
namespace "ibm-cas" deleted
[1/5] Waiting for namespace/ibm-cas to terminate...
[2/5] Waiting for namespace/ibm-cas to terminate...
namespace/ibm-cas deleted successfully.

============================================================
INFO Completed: Delete Namespace
============================================================


IBM CAS gets cleaned up successfully.
```