### PR TITLE
hotfix 2.11.0: Update image for 60235

### DIFF
--- a/backup-restore/hotfixes/2.11.0/br-2.11.0patch-offline-mirror.sh
+++ b/backup-restore/hotfixes/2.11.0/br-2.11.0patch-offline-mirror.sh
@@ -12,7 +12,7 @@ TARGET_PATH="$1"
 export TARGET_PATH
 set -e
 
-TRANSACTIONMANAGER=guardian-transaction-manager@sha256:950a851ff61b748abc0e141922c17eaca6a944e3f8a1d74b73855322a0f74568
+TRANSACTIONMANAGER=guardian-transaction-manager@sha256:6465fadda4ca4402d098932d68563209ecfcc6ca7aa3e5accee02be98e4404dd
 
 declare -a IMAGES=(
   $TRANSACTIONMANAGER

--- a/backup-restore/hotfixes/2.11.0/br-post-install-patch-2.11.0.sh
+++ b/backup-restore/hotfixes/2.11.0/br-post-install-patch-2.11.0.sh
@@ -25,7 +25,7 @@ else
     patch_usage
     exit 1
 fi
-HOTFIX_NUMBER=1
+HOTFIX_NUMBER=2
 EXPECTED_VERSION=2.11.0
 
 mkdir -p /tmp/br-post-install-patch-2.11.0
@@ -101,7 +101,7 @@ fi
 if (oc get deployment -n $BR_NS transaction-manager -o yaml > $DIR/transaction-manager-deployment.save.yaml)
 then
     echo "Patching deployment/transaction-manager image..."
-    oc set image deployment/transaction-manager --namespace $BR_NS transaction-manager=cp.icr.io/cp/bnr/guardian-transaction-manager@sha256:950a851ff61b748abc0e141922c17eaca6a944e3f8a1d74b73855322a0f74568
+    oc set image deployment/transaction-manager --namespace $BR_NS transaction-manager=cp.icr.io/cp/bnr/guardian-transaction-manager@sha256:6465fadda4ca4402d098932d68563209ecfcc6ca7aa3e5accee02be98e4404dd
     oc rollout status --namespace $BR_NS --timeout=65s deployment/transaction-manager
 else
     echo "ERROR: Failed to save original transaction-manager deployment. Skipped updates."

--- a/backup-restore/hotfixes/2.11.0/hotfixes.txt
+++ b/backup-restore/hotfixes/2.11.0/hotfixes.txt
@@ -1,3 +1,4 @@
 This hotfix fixes the following Backup & Restore issues:
 
     1.  Removed the validation for label, if label more than 63 character label will be truncated for Velero Backup CR.(Issue: 59712)
+    2.  Fix KeyError while accessing intrinsic variable APP.namespace.name during restore.(Issue: 60235)


### PR DESCRIPTION

<details>
<summary>Execution log:</summary>
<br>
<pre>
$ ./backup-restore/hotfixes/2.11.0/br-post-install-patch-2.11.0.sh -sds
Writing output of br-post-install-patch-2.11.0.sh script to /tmp/br-post-install-patch-2.11.0/br-post-install-patch-2.11.0_194547_log.txt
Checking for required commands: oc jq
Patching deployment/transaction-manager image...
deployment.apps/transaction-manager image updated
Waiting for deployment "transaction-manager" rollout to finish: 1 old replicas are pending termination...
Waiting for deployment "transaction-manager" rollout to finish: 1 old replicas are pending termination...
deployment "transaction-manager" successfully rolled out
configmap/bnr-hotfixes created
Please verify that these pods have successfully restarted after hotfix update in their corresponding namespace:
  ibm-backup-restore       : transaction-manager

<br>
$ oc get deploy transaction-manager -n ibm-backup-restore -o yaml | grep "image: "
        image: cp.icr.io/cp/bnr/guardian-transaction-manager@sha256:6465fadda4ca4402d098932d68563209ecfcc6ca7aa3e5accee02be98e4404dd
</pre>
</details>