### PR TITLE
2.11 Node-agent pods must be restarted after 2.11 hotfix

### DIFF
--- a/backup-restore/hotfixes/2.11.0/br-post-install-patch-2.11.0.sh
+++ b/backup-restore/hotfixes/2.11.0/br-post-install-patch-2.11.0.sh
@@ -319,3 +319,7 @@ fi
 printf "  %-${#BR_NS}s: %s\n" "$BR_NS" "transaction-manager"
 printf "  %-${#BR_NS}s: %s\n" "$BR_NS" "dbr-controller"
 printf "  %-${#ISF_NS}s: %s\n" "$ISF_NS" "isf-data-protection-operator-controller-manager"
+
+echo "Please verify that the pods for the following daemonsets have successfully restarted for Openshift 4.18 and lower:"
+printf "  %-${#BR_NS}s: %s\n" "$BR_NS" "node-agent"
+echo "Manually restart node-agent pods if they haven’t been restarted."


### PR DESCRIPTION
Changed wording for 2.11 hotfix script.
