### PR TITLE
69600 hotfix

### DIFF
--- a/backup-restore/hotfixes/2.11.0/br-2.11.0patch-offline-mirror.sh
+++ b/backup-restore/hotfixes/2.11.0/br-2.11.0patch-offline-mirror.sh
@@ -15,6 +15,7 @@ set -e
 TRANSACTIONMANAGER=guardian-transaction-manager@sha256:25bfde6b666b864ee90541ca872c61d4f6be0b19da22fb7edf8c4156992955ec
 OADP_VELERO_14=fbr-velero@sha256:1fd0dc018672507b24148a0fe71e69f91ab31576c7fa070c599d7a446b5095aa
 OADP_VELERO_15=fbr-velero15@sha256:7a57d50f9c1b6a338edf310c5e69182ac98ec6338376b4ddc0474ff7e592f4f4
+IDP_AGENT_OPERATOR=idp-agent-operator@sha256:7f1b66ca1876c23c3705da181499ba3ec015d90e3b8ea9b455af78763814cfa6
 
 JOBMANAGER=guardian-job-manager@sha256:62fb326d26758d531f1912bd28238468f616553dfec99e2d704729f6caf39349
 BACKUPSERVICE=guardian-backup-service@sha256:6517b55c0c3ab8aa44f2e5cc4554ee3efb49211f7eb8840623c4160076485611
@@ -30,6 +31,10 @@ declare -a IMAGES=(
   $BACKUPSERVICE
 )
 
+declare -a CPOPENIMAGES=(
+  $IDP_AGENT_OPERATOR
+)
+
 declare -a FUSIONIMAGES_HCI=(
   "$ISFDATAPROTECTION_HCI"
 )
@@ -42,6 +47,12 @@ for IMAGE in "${IMAGES[@]}"; do
   DESTINATION=docker://$TARGET_PATH/cp/bnr/$IMAGE
   echo -e "Copying\n Image: $IMAGE\n Destination: docker://$TARGET_PATH/cp/bnr/$IMAGE\n"
   skopeo copy --insecure-policy --preserve-digests --all docker://cp.icr.io/cp/bnr/$IMAGE $DESTINATION
+done
+
+for IMAGE in "${CPOPENIMAGES[@]}"; do
+  DESTINATION=docker://$TARGET_PATH/cpopen/$IMAGE
+  echo -e "Copying\n Image: $IMAGE\n Destination: docker://$TARGET_PATH/cpopen/$IMAGE\n"
+  skopeo copy --insecure-policy --preserve-digests --all docker://icr.io/cpopen/$IMAGE $DESTINATION
 done
 
 for FUSIONHCIIMAGE in "${FUSIONIMAGES_HCI[@]}"; do

--- a/backup-restore/hotfixes/2.11.0/br-post-install-patch-2.11.0.sh
+++ b/backup-restore/hotfixes/2.11.0/br-post-install-patch-2.11.0.sh
@@ -25,7 +25,7 @@ else
     patch_usage
     exit 1
 fi
-HOTFIX_NUMBER=7
+HOTFIX_NUMBER=8
 EXPECTED_VERSION=2.11.0
 
 mkdir -p /tmp/br-post-install-patch-2.11.0
@@ -183,6 +183,46 @@ set_velero_image() {
     fi
 }
 
+# Updates operator CSVs
+update_operator_csv() {
+    name="$1"
+    deployment_name="$2"
+    image="$3"
+    csv_ns="$BR_NS"
+
+    if (oc get csv -n "$csv_ns" "$name" -o yaml > "$DIR/${name}.save.yaml"); then
+        echo "Scaling down deployment: $deployment_name ..."
+        [ -z "$DRY_RUN" ] && oc scale deployment -n "$csv_ns" "$deployment_name" --replicas=0
+
+        echo "Patching clusterserviceversion/$name (deployment: $deployment_name, image: $image) ..."
+        dep_index=$(oc get csv -n "$csv_ns" "$name" -o json | jq "[.spec.install.spec.deployments[].name] | index(\"$deployment_name\")")
+
+        if [[ "$dep_index" == "null" ]]; then
+            echo "ERROR: Deployment '$deployment_name' not found in CSV $name"
+            return 1
+        fi
+        patches=()
+        container_index=0
+        for cname in $(oc get csv -n "$csv_ns" "$name" -o json \
+            | jq -r ".spec.install.spec.deployments[$dep_index].spec.template.spec.containers[].name"); do
+            if [[ "$cname" == "manager" ]]; then
+                patches+=("{\"op\":\"replace\",\"path\":\"/spec/install/spec/deployments/${dep_index}/spec/template/spec/containers/${container_index}/image\",\"value\":\"${image}\"}")
+            fi
+            ((container_index++))
+        done
+
+        patch_json="[$(IFS=,; echo "${patches[*]}")]"
+        [ -z "$DRY_RUN" ] &&  oc patch csv -n "$csv_ns" "$name" --type='json' -p "$patch_json"
+        [ -n "$DRY_RUN" ] && oc patch csv -n "$csv_ns" "$name" --type='json' -p "$patch_json" --dry-run=client -o yaml > "$DIR/${name}.patch.yaml"
+
+        echo "Scaling up deployment: $deployment_name ..."
+        [ -z "$DRY_RUN" ] && oc scale deployment -n "$csv_ns" "$deployment_name" --replicas=1
+
+    else
+        echo "ERROR: Failed to save original clusterserviceversion/$name. Skipped updates."
+    fi
+}
+
 update_isf_operator_csv() {
     name=$1
     image=$2
@@ -306,6 +346,12 @@ fi
 [ "$PATCH" == "HCI" ] && isfdataprotection_img=cp.icr.io/cp/fusion-hci/isf-data-protection-operator@sha256:63bdb2f47b02366fe39f98bb5d811878b44feed235bca22e0f16586a387c9a80
 [ "$PATCH" == "SDS" ] && isfdataprotection_img=cp.icr.io/cp/fusion-sds/isf-data-protection-operator@sha256:bdfe6ba1101d1de4dab81e513b2f4c7492da19b26186d20ee58d955689cb0be3
 update_isf_operator_csv isf-operator.v2.11.0 "${isfdataprotection_img}"
+
+
+# update idp-agent-operator
+guardianidpagentoperator_img=icr.io/cpopen/idp-agent-operator@sha256:7f1b66ca1876c23c3705da181499ba3ec015d90e3b8ea9b455af78763814cfa6
+update_operator_csv ibm-dataprotectionagent.v2.11.0 ibm-dataprotectionagent-controller-manager "${guardianidpagentoperator_img}"
+
 
 update_tm_env
 transactionmanager_img=cp.icr.io/cp/bnr/guardian-transaction-manager@sha256:25bfde6b666b864ee90541ca872c61d4f6be0b19da22fb7edf8c4156992955ec

--- a/backup-restore/hotfixes/2.11.0/hotfix_8.txt
+++ b/backup-restore/hotfixes/2.11.0/hotfix_8.txt
@@ -1,0 +1,3 @@
+This hotfix fixes the following Backup & Restore issues:
+
+1. Fixed issue with missing fields in guardian-configmap which causes spoke upgrades to be stuck. (#69600)

--- a/backup-restore/hotfixes/2.12.0/br-post-install-patch-2.12.0.sh
+++ b/backup-restore/hotfixes/2.12.0/br-post-install-patch-2.12.0.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Run this script on hub and spoke clusters to apply the latest hotfixes for 2.12.0 release.
-HOTFIX_NUMBER=3
+HOTFIX_NUMBER=4
 EXPECTED_VERSION=2.12.0
 IMAGE_SOURCE="br-2.12.0patch-offline-mirror.sh"
 
@@ -192,6 +192,46 @@ check_for_required_dependencies() {
     fi
 }
 
+# Updates operator CSVs
+update_operator_csv() {
+    name="$1"
+    deployment_name="$2"
+    image="$3"
+    csv_ns="$BR_NS"
+
+    if (oc get csv -n "$csv_ns" "$name" -o yaml > "$DIR/${name}.save.yaml"); then
+        echo "Scaling down deployment: $deployment_name ..."
+        [ -z "$DRY_RUN" ] && oc scale deployment -n "$csv_ns" "$deployment_name" --replicas=0
+
+        echo "Patching clusterserviceversion/$name (deployment: $deployment_name, image: $image) ..."
+        dep_index=$(oc get csv -n "$csv_ns" "$name" -o json | jq "[.spec.install.spec.deployments[].name] | index(\"$deployment_name\")")
+
+        if [[ "$dep_index" == "null" ]]; then
+            echo "ERROR: Deployment '$deployment_name' not found in CSV $name"
+            return 1
+        fi
+        patches=()
+        container_index=0
+        for cname in $(oc get csv -n "$csv_ns" "$name" -o json \
+            | jq -r ".spec.install.spec.deployments[$dep_index].spec.template.spec.containers[].name"); do
+            if [[ "$cname" == "manager" ]]; then
+                patches+=("{\"op\":\"replace\",\"path\":\"/spec/install/spec/deployments/${dep_index}/spec/template/spec/containers/${container_index}/image\",\"value\":\"${image}\"}")
+            fi
+            ((container_index++))
+        done
+
+        patch_json="[$(IFS=,; echo "${patches[*]}")]"
+        [ -z "$DRY_RUN" ] &&  oc patch csv -n "$csv_ns" "$name" --type='json' -p "$patch_json"
+        [ -n "$DRY_RUN" ] && oc patch csv -n "$csv_ns" "$name" --type='json' -p "$patch_json" --dry-run=client -o yaml > "$DIR/${name}.patch.yaml"
+
+        echo "Scaling up deployment: $deployment_name ..."
+        [ -z "$DRY_RUN" ] && oc scale deployment -n "$csv_ns" "$deployment_name" --replicas=1
+
+    else
+        echo "ERROR: Failed to save original clusterserviceversion/$name. Skipped updates."
+    fi
+}
+
 check_for_required_dependencies
 
 oc whoami > /dev/null || ( echo "Not logged in to your cluster" ; exit 1)
@@ -229,17 +269,19 @@ fi
 # make hub/cluster spoke connection settings to reconcile and resolve to the configmap
 resolve_hub_connection $HUB
 
+# update idp-agent-operator
+guardianidpagentoperator_img=$(build_icr_path ${CPOPEN_PREFIX} ${IDP_AGENT_OPERATOR})
+update_operator_csv ibm-dataprotectionagent.v2.12.0 ibm-dataprotectionagent-controller-manager "${guardianidpagentoperator_img}"
+
 # update transaction-manager
 tm_image=$(build_icr_path ${BNR_PREFIX} ${TRANSACTIONMANAGER})
 set_deployment_image transaction-manager transaction-manager "${tm_image}"
 set_deployment_image dbr-controller dbr-controller "${tm_image}"
 
-hotfix="hotfix-${EXPECTED_VERSION}.${HOTFIX_NUMBER}"
-update_hotfix_configmap ${hotfix}
-
 echo "Please verify that the pods for the following deployment have successfully restarted:"
 printf "  %-${#BR_NS}s: %s\n" "$BR_NS" "transaction-manager"
 printf "  %-${#BR_NS}s: %s\n" "$BR_NS" "dbr-controller"
+printf "  %-${#BR_NS}s: %s\n" "$BR_NS" "ibm-dataprotectionagent-controller-manager"
 
 # update oadp velero
 oadp_velero_14=$(build_icr_path ${BNR_PREFIX} ${OADP_VELERO_14})
@@ -251,3 +293,6 @@ printf "  %-${#BR_NS}s: %s\n" "$BR_NS" "velero"
 
 echo "Please verify that the pods for the following daemonsets have successfully restarted for OpenShift 4.18 and lower:"
 printf "  %-${#BR_NS}s: %s\n" "$BR_NS" "node-agent"
+
+hotfix="hotfix-${EXPECTED_VERSION}.${HOTFIX_NUMBER}"
+update_hotfix_configmap ${hotfix}

--- a/backup-restore/hotfixes/2.12.0/hotfix_4.txt
+++ b/backup-restore/hotfixes/2.12.0/hotfix_4.txt
@@ -1,0 +1,3 @@
+This hotfix fixes the following Backup & Restore issues:
+
+1. Fixed issue with missing fields in guardian-configmap which causes spoke upgrades to be stuck. (#69600)

--- a/backup-restore/hotfixes/2.12.1/br-2.12.1patch-offline-mirror.sh
+++ b/backup-restore/hotfixes/2.12.1/br-2.12.1patch-offline-mirror.sh
@@ -9,9 +9,8 @@ HCI_PREFIX="cp.icr.io/cp/fusion-hci"
 SDS_PREFIX="cp.icr.io/cp/fusion-sds"
 CPOPEN_PREFIX="icr.io/cpopen"
 
-OADP_VELERO_14=fbr-velero@sha256:379a6d6a6dbe78fd09c3aa91b2f3fb44dff514ff5d62a1654cc1b3a126b8aee9
-TRANSACTIONMANAGER=guardian-transaction-manager@sha256:7bb7230a0e6fedf318e7670698575b91b211dd6e457ae7ac33665ae8c1992d48
-IDP_AGENT_OPERATOR=idp-agent-operator@sha256:ed13cba6e1821d300846a165ad8b1228dd39c79ec2f0008a8649b157eeab518e
+
+IDP_AGENT_OPERATOR=idp-agent-operator@sha256:a12594769e8c0e718280875a22006265385e6d866b7b4507d6065e16a0dfd5bf
 
 
 #check_cmd:
@@ -73,8 +72,6 @@ copy_images() {
 }
 
 declare -a IMAGES=(
-  $OADP_VELERO_14
-  $TRANSACTIONMANAGER
 )
 
 declare -a CPOPENIMAGES=(
@@ -96,7 +93,6 @@ for IMAGE in "${IMAGES[@]}"; do
   ICR_PATH=
   ICR_IMAGE_PATHS+=($(build_icr_path ${BNR_PREFIX} ${IMAGE}))
 done
-
 
 for IMAGE in "${CPOPENIMAGES[@]}"; do
   ICR_PATH=

--- a/backup-restore/hotfixes/2.12.1/br-post-install-patch-2.12.1.sh
+++ b/backup-restore/hotfixes/2.12.1/br-post-install-patch-2.12.1.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 # Run this script on hub and spoke clusters to apply the latest hotfixes for 2.12.1 release.
-HOTFIX_NUMBER=1
+HOTFIX_NUMBER=2
 EXPECTED_VERSION=2.12.1
+IMAGE_SOURCE="br-2.12.1patch-offline-mirror.sh"
 
 patch_usage() {
     echo "Patches the Fusion Backup & Restore install to ${EXPECTED_VERSION} hotfix ${HOTFIX_NUMBER}".
@@ -51,6 +52,16 @@ while [[ $# -gt 0 ]]; do
         ;;
     esac
 done
+
+if [ ! -f "$IMAGE_SOURCE" ]; then
+    echo "Container image sourcefile ${IMAGE_SOURCE} is missing. The hotfix"
+    echo "requires the container image source file to execute. This file can"
+    echo "be found on the hotfix repository."
+    # file not found is errno 2
+    exit 2
+fi
+
+source "${IMAGE_SOURCE}"
 
 # use selected directory for saving logs, patches, and old values
 # if not, use the default generated directory
@@ -181,6 +192,46 @@ check_for_required_dependencies() {
     fi
 }
 
+# Updates operator CSVs
+update_operator_csv() {
+    name="$1"
+    deployment_name="$2"
+    image="$3"
+    csv_ns="$BR_NS"
+
+    if (oc get csv -n "$csv_ns" "$name" -o yaml > "$DIR/${name}.save.yaml"); then
+        echo "Scaling down deployment: $deployment_name ..."
+        [ -z "$DRY_RUN" ] && oc scale deployment -n "$csv_ns" "$deployment_name" --replicas=0
+
+        echo "Patching clusterserviceversion/$name (deployment: $deployment_name, image: $image) ..."
+        dep_index=$(oc get csv -n "$csv_ns" "$name" -o json | jq "[.spec.install.spec.deployments[].name] | index(\"$deployment_name\")")
+
+        if [[ "$dep_index" == "null" ]]; then
+            echo "ERROR: Deployment '$deployment_name' not found in CSV $name"
+            return 1
+        fi
+        patches=()
+        container_index=0
+        for cname in $(oc get csv -n "$csv_ns" "$name" -o json \
+            | jq -r ".spec.install.spec.deployments[$dep_index].spec.template.spec.containers[].name"); do
+            if [[ "$cname" == "manager" ]]; then
+                patches+=("{\"op\":\"replace\",\"path\":\"/spec/install/spec/deployments/${dep_index}/spec/template/spec/containers/${container_index}/image\",\"value\":\"${image}\"}")
+            fi
+            ((container_index++))
+        done
+
+        patch_json="[$(IFS=,; echo "${patches[*]}")]"
+        [ -z "$DRY_RUN" ] &&  oc patch csv -n "$csv_ns" "$name" --type='json' -p "$patch_json"
+        [ -n "$DRY_RUN" ] && oc patch csv -n "$csv_ns" "$name" --type='json' -p "$patch_json" --dry-run=client -o yaml > "$DIR/${name}.patch.yaml"
+
+        echo "Scaling up deployment: $deployment_name ..."
+        [ -z "$DRY_RUN" ] && oc scale deployment -n "$csv_ns" "$deployment_name" --replicas=1
+
+    else
+        echo "ERROR: Failed to save original clusterserviceversion/$name. Skipped updates."
+    fi
+}
+
 check_for_required_dependencies
 
 oc whoami > /dev/null || ( echo "Not logged in to your cluster" ; exit 1)
@@ -217,3 +268,13 @@ fi
 
 # make hub/cluster spoke connection settings to reconcile and resolve to the configmap
 resolve_hub_connection $HUB
+
+# update idp-agent-operator
+guardianidpagentoperator_img=$(build_icr_path ${CPOPEN_PREFIX} ${IDP_AGENT_OPERATOR})
+update_operator_csv ibm-dataprotectionagent.v2.12.1 ibm-dataprotectionagent-controller-manager "${guardianidpagentoperator_img}"
+
+hotfix="hotfix-${EXPECTED_VERSION}.${HOTFIX_NUMBER}"
+update_hotfix_configmap ${hotfix}
+
+echo "Please verify that the pods for the following deployment have successfully restarted:"
+printf "  %-${#BR_NS}s: %s\n" "$BR_NS" "ibm-dataprotectionagent-controller-manager"

--- a/backup-restore/hotfixes/2.12.1/hotfix_2.txt
+++ b/backup-restore/hotfixes/2.12.1/hotfix_2.txt
@@ -1,0 +1,3 @@
+This hotfix fixes the following Backup & Restore issues:
+
+1. Fix issue with missing fields in guardian-configmap which causes spoke upgrades to be stuck. (#69600)


### PR DESCRIPTION
Updated 2.11.0, 2.12.0 and 2.12.1 scripts to patch idp-agent-operator images promoted in the following issues:

https://github.ibm.com/ProjectAbell/abell-tracking/issues/71163
https://github.ibm.com/ProjectAbell/abell-tracking/issues/71164
https://github.ibm.com/ProjectAbell/abell-tracking/issues/71288

Changes made:
Copied over update_isf_operator_csv from previous version script and called it to update idp-agent-operator image
Changes in offline script for a new location to copy from (icr.io.cpopen)
