### PR TITLE
Changes for bash inconsistencies

### DIFF
--- a/backup-restore/hotfixes/2.10.0/br-post-install-patch-2.10.0.sh
+++ b/backup-restore/hotfixes/2.10.0/br-post-install-patch-2.10.0.sh
@@ -169,7 +169,7 @@ update_operator_csv() {
             if [[ "$cname" == "manager" ]]; then
                 patches+=("{\"op\":\"replace\",\"path\":\"/spec/install/spec/deployments/${dep_index}/spec/template/spec/containers/${container_index}/image\",\"value\":\"${image}\"}")
             fi
-            ((container_index++))
+            ((container_index++)) || true
         done
 
         patch_json="[$(IFS=,; echo "${patches[*]}")]"

--- a/backup-restore/hotfixes/2.10.1/br-post-install-patch-2.10.1.sh
+++ b/backup-restore/hotfixes/2.10.1/br-post-install-patch-2.10.1.sh
@@ -145,7 +145,7 @@ update_operator_csv() {
             if [[ "$cname" == "manager" ]]; then
                 patches+=("{\"op\":\"replace\",\"path\":\"/spec/install/spec/deployments/${dep_index}/spec/template/spec/containers/${container_index}/image\",\"value\":\"${image}\"}")
             fi
-            ((container_index++))
+            ((container_index++)) || true
         done
 
         patch_json="[$(IFS=,; echo "${patches[*]}")]"

--- a/backup-restore/hotfixes/2.11.0/br-post-install-patch-2.11.0.sh
+++ b/backup-restore/hotfixes/2.11.0/br-post-install-patch-2.11.0.sh
@@ -208,7 +208,7 @@ update_operator_csv() {
             if [[ "$cname" == "manager" ]]; then
                 patches+=("{\"op\":\"replace\",\"path\":\"/spec/install/spec/deployments/${dep_index}/spec/template/spec/containers/${container_index}/image\",\"value\":\"${image}\"}")
             fi
-            ((container_index++))
+            ((container_index++)) || true
         done
 
         patch_json="[$(IFS=,; echo "${patches[*]}")]"

--- a/backup-restore/hotfixes/2.12.0/br-post-install-patch-2.12.0.sh
+++ b/backup-restore/hotfixes/2.12.0/br-post-install-patch-2.12.0.sh
@@ -217,7 +217,7 @@ update_operator_csv() {
             if [[ "$cname" == "manager" ]]; then
                 patches+=("{\"op\":\"replace\",\"path\":\"/spec/install/spec/deployments/${dep_index}/spec/template/spec/containers/${container_index}/image\",\"value\":\"${image}\"}")
             fi
-            ((container_index++))
+            ((container_index++)) || true
         done
 
         patch_json="[$(IFS=,; echo "${patches[*]}")]"

--- a/backup-restore/hotfixes/2.12.1/br-post-install-patch-2.12.1.sh
+++ b/backup-restore/hotfixes/2.12.1/br-post-install-patch-2.12.1.sh
@@ -217,7 +217,7 @@ update_operator_csv() {
             if [[ "$cname" == "manager" ]]; then
                 patches+=("{\"op\":\"replace\",\"path\":\"/spec/install/spec/deployments/${dep_index}/spec/template/spec/containers/${container_index}/image\",\"value\":\"${image}\"}")
             fi
-            ((container_index++))
+            ((container_index++)) || true
         done
 
         patch_json="[$(IFS=,; echo "${patches[*]}")]"


### PR DESCRIPTION
_((container_index++))_ causing script to exit on certain bash versions. Changing it to _((container_index++)) || true_

Fix for issue reported in https://github.ibm.com/ProjectAbell/abell-tracking/issues/69600#issuecomment-190027060