### PR TITLE
2.12.1 hotfix 3

### DIFF
--- a/backup-restore/hotfixes/2.12.1/README.MD
+++ b/backup-restore/hotfixes/2.12.1/README.MD
@@ -38,8 +38,8 @@ Hotfixes are cumulative patches that address specific issues in the Backup & Res
 
 Before applying the hotfix, download the following files:
 
-- `br-post-install-patch-2.12.1.sh` - Main hotfix installation script
-- `br-2.12.1patch-offline-mirror.sh` - Offline image mirroring script (for air-gapped environments)
+- `br-post-install-patch-2.12.1.sh` 
+- `br-2.12.1patch-offline-mirror.sh` 
 
 ### Installation Steps
 
@@ -78,10 +78,11 @@ If your environment does not have direct internet access, mirror the hotfix imag
 
 **Installation procedure:**
 
-1. **Download the hotfix script** to your local system:
+1. **Download the hotfix scripts** to your local system:
    ```bash
-   # Verify the script is present
+   # Verify the scripts are present
    ls -lh br-post-install-patch-2.12.1.sh
+   ls -lh br-2.12.1patch-offline-mirror.sh
    ```
 
 2. **Make the script executable:**
@@ -91,12 +92,12 @@ If your environment does not have direct internet access, mirror the hotfix imag
 
 3. **Execute the hotfix script** with the appropriate deployment type flag:
 
-   **For HCI (Hyperconverged Infrastructure) deployments:**
+   **For HCI deployments:**
    ```bash
    ./br-post-install-patch-2.12.1.sh -hci
    ```
 
-   **For SDS (Software-Defined Storage) deployments:**
+   **For SDS deployments:**
    ```bash
    ./br-post-install-patch-2.12.1.sh -sds
    ```

--- a/backup-restore/hotfixes/2.12.1/README.MD
+++ b/backup-restore/hotfixes/2.12.1/README.MD
@@ -8,7 +8,7 @@ Hotfixes are cumulative patches that address specific issues in the Backup & Res
 
 ## Hotfix 3 (Latest)
 
-**Release Date:** Latest hotfix for 2.12.1
+**Release Date:** Apr 27th, 2026
 
 ### Issues Fixed
 
@@ -30,7 +30,7 @@ Hotfixes are cumulative patches that address specific issues in the Backup & Res
 ### Issues Fixed
 
 1. **Force idp-agent-operator to reconcile spoke-hub communication settings due to incorrect state-1 mirroring of ConfigMap guardian-configmap**  (#69600)
-   - 
+
 
 ## Installation
 

--- a/backup-restore/hotfixes/2.12.1/README.MD
+++ b/backup-restore/hotfixes/2.12.1/README.MD
@@ -38,8 +38,8 @@ Hotfixes are cumulative patches that address specific issues in the Backup & Res
 
 Before applying the hotfix, download the following files:
 
-- `br-post-install-patch-2.12.1.sh` 
-- `br-2.12.1patch-offline-mirror.sh` 
+- [`br-post-install-patch-2.12.1.sh`](br-post-install-patch-2.12.1.sh) 
+- [`br-2.12.1patch-offline-mirror.sh`](br-2.12.1patch-offline-mirror.sh) 
 
 ### Installation Steps
 

--- a/backup-restore/hotfixes/2.12.1/README.MD
+++ b/backup-restore/hotfixes/2.12.1/README.MD
@@ -1,0 +1,124 @@
+# Backup & Restore Hotfixes for Version 2.12.1
+
+This document lists all hotfixes available for IBM Storage Fusion Backup & Restore version 2.12.1.
+
+## Overview
+
+Hotfixes are cumulative patches that address specific issues in the Backup & Restore component. Each hotfix builds upon previous fixes and should be applied to both hub and spoke clusters.
+
+## Hotfix 3 (Latest)
+
+**Release Date:** Latest hotfix for 2.12.1
+
+### Issues Fixed
+
+
+1. **Fusion creates hundreds of pods during cleanup jobs** (#69959)
+2. **Backup jobs remain in pending state on spoke** (#71255)
+3. **Slow service protection backup** (#71410) 
+   
+
+## Hotfix 2
+
+### Issues Fixed
+
+1. **Fix issue with missing fields in guardian-configmap which causes spoke upgrades to be stuck** (#69600)
+  
+
+## Hotfix 1
+
+### Issues Fixed
+
+1. **Force idp-agent-operator to reconcile spoke-hub communication settings due to incorrect state-1 mirroring of ConfigMap guardian-configmap**  (#69600)
+   - 
+
+## Installation
+
+### Required Files
+
+Before applying the hotfix, download the following files:
+
+- `br-post-install-patch-2.12.1.sh` - Main hotfix installation script
+- `br-2.12.1patch-offline-mirror.sh` - Offline image mirroring script (for air-gapped environments)
+
+### Installation Steps
+
+The hotfix must be applied to **the hub and all spoke cluster** in your environment.
+
+#### Step 1: Offline Image Mirroring (Air-Gapped Environments Only)
+
+If your environment does not have direct internet access, mirror the hotfix images to your local registry before applying the hotfix.
+
+**Prerequisites:**
+- Authenticate to both source and destination registries:
+  ```bash
+  # Login to IBM Container Registry
+  podman login cp.icr.io
+  
+  # Login to your local registry
+  podman login <YOUR_LOCAL_REGISTRY>
+  ```
+
+**Execute the mirroring script:**
+```bash
+./br-2.12.1patch-offline-mirror.sh <TARGET_PATH>
+```
+
+**Parameters:**
+- `<TARGET_PATH>`: Your local registry path in format `$LOCAL_ISF_REGISTRY/$LOCAL_ISF_REPOSITORY`
+
+**Example:**
+```bash
+./br-2.12.1patch-offline-mirror.sh myregistry.example.com:5000/isf-images
+```
+
+> **Note:** Skip this step if your cluster has direct internet access.
+
+#### Step 2: Apply the Hotfix
+
+**Installation procedure:**
+
+1. **Download the hotfix script** to your local system:
+   ```bash
+   # Verify the script is present
+   ls -lh br-post-install-patch-2.12.1.sh
+   ```
+
+2. **Make the script executable:**
+   ```bash
+   chmod +x br-post-install-patch-2.12.1.sh
+   ```
+
+3. **Execute the hotfix script** with the appropriate deployment type flag:
+
+   **For HCI (Hyperconverged Infrastructure) deployments:**
+   ```bash
+   ./br-post-install-patch-2.12.1.sh -hci
+   ```
+
+   **For SDS (Software-Defined Storage) deployments:**
+   ```bash
+   ./br-post-install-patch-2.12.1.sh -sds
+   ```
+
+
+## Prerequisites
+
+- IBM Storage Fusion Backup & Restore version 2.12.1 must be installed
+- Cluster administrator access (kubectl/oc CLI configured)
+- For offline installations: Access to container registry for image mirroring
+
+## Important Notes
+
+- **Hotfixes are cumulative**: The latest hotfix includes all fixes from the previous hotfixes
+- **Apply to all clusters**: Run the patch script on both hub and spoke clusters
+
+
+## Support
+
+For issues or questions regarding these hotfixes, please refer to the IBM Storage Fusion documentation or contact IBM Support.
+
+## Related Files
+
+- `br-post-install-patch-2.12.1.sh` - Main hotfix installation script
+- `br-2.12.1patch-offline-mirror.sh` - Offline image mirroring script

--- a/backup-restore/hotfixes/2.12.1/br-2.12.1patch-offline-mirror.sh
+++ b/backup-restore/hotfixes/2.12.1/br-2.12.1patch-offline-mirror.sh
@@ -9,7 +9,7 @@ HCI_PREFIX="cp.icr.io/cp/fusion-hci"
 SDS_PREFIX="cp.icr.io/cp/fusion-sds"
 CPOPEN_PREFIX="icr.io/cpopen"
 
-
+TRANSACTIONMANAGER=guardian-transaction-manager@sha256:38dce505864c7644b10da8a5f7daf05e21de510cd41c09a925444e3f0a52a99e
 IDP_AGENT_OPERATOR=idp-agent-operator@sha256:a12594769e8c0e718280875a22006265385e6d866b7b4507d6065e16a0dfd5bf
 
 
@@ -72,6 +72,7 @@ copy_images() {
 }
 
 declare -a IMAGES=(
+  $TRANSACTIONMANAGER
 )
 
 declare -a CPOPENIMAGES=(

--- a/backup-restore/hotfixes/2.12.1/br-post-install-patch-2.12.1.sh
+++ b/backup-restore/hotfixes/2.12.1/br-post-install-patch-2.12.1.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Run this script on hub and spoke clusters to apply the latest hotfixes for 2.12.1 release.
-HOTFIX_NUMBER=2
+HOTFIX_NUMBER=3
 EXPECTED_VERSION=2.12.1
 IMAGE_SOURCE="br-2.12.1patch-offline-mirror.sh"
 
@@ -273,8 +273,15 @@ resolve_hub_connection $HUB
 guardianidpagentoperator_img=$(build_icr_path ${CPOPEN_PREFIX} ${IDP_AGENT_OPERATOR})
 update_operator_csv ibm-dataprotectionagent.v2.12.1 ibm-dataprotectionagent-controller-manager "${guardianidpagentoperator_img}"
 
+# update transaction-manager
+tm_image=$(build_icr_path ${BNR_PREFIX} ${TRANSACTIONMANAGER})
+set_deployment_image transaction-manager transaction-manager "${tm_image}"
+set_deployment_image dbr-controller dbr-controller "${tm_image}"
+
 hotfix="hotfix-${EXPECTED_VERSION}.${HOTFIX_NUMBER}"
 update_hotfix_configmap ${hotfix}
 
 echo "Please verify that the pods for the following deployment have successfully restarted:"
+printf "  %-${#BR_NS}s: %s\n" "$BR_NS" "transaction-manager"
+printf "  %-${#BR_NS}s: %s\n" "$BR_NS" "dbr-controller"
 printf "  %-${#BR_NS}s: %s\n" "$BR_NS" "ibm-dataprotectionagent-controller-manager"


### PR DESCRIPTION
2.12.1 hotfix 3 changes
- Updated script to patch TM image. icr image generated in https://github.ibm.com/ProjectAbell/abell-tracking/issues/72638
- Added a README file with list of issues fixed in each hotfix. Eventually, the support page can link to this README instead of having another copy of instructions.