### PR TITLE
Fusion Developer Hub - Update Readme and default branch in Application manifest

### DIFF
--- a/AI/quickstarts/fusion-developerhub/QUICKSTART.md
+++ b/AI/quickstarts/fusion-developerhub/QUICKSTART.md
@@ -126,12 +126,22 @@ IBM Fusion Developer Hub is an enterprise-ready developer portal built on Red Ha
 
 ## Installation
 
-Deploy IBM Fusion Developer Hub using either Helm for direct installation or GitOps with ArgoCD for automated, Git-driven deployments. Choose the method that best fits your workflow and infrastructure management approach.
-
 **In this section:**
 - [Prerequisites](#prerequisites)
 - [2.1 Deploy using Helm](#21-deploy-using-helm)
 - [2.2 Deploy using GitOps](#22-deploy-using-gitops)
+
+Deploy IBM Fusion Developer Hub using either Helm for direct installation or GitOps with ArgoCD for automated, Git-driven deployments. Choose the method that best fits your workflow and infrastructure management approach.
+
+For a direct Helm deployment, including prerequisites, operator installation, and configuration, see [2.1 Deploy using Helm](#21-deploy-using-helm) below or follow the detailed [Fusion Developer Hub Helm Quickstart Guide](https://community.ibm.com/community/user/blogs/anushka-jaiswal/2026/05/29/quickstart-developer-hub-on-ibm-fusion-with-redhat) on IBM Community.
+
+For production deployments, GitOps is the recommended approach because it provides a declarative and auditable deployment model, where configuration changes are tracked in Git and applied through OpenShift GitOps (ArgoCD).
+
+Before proceeding with the GitOps-based installation, OpenShift GitOps (ArgoCD) must be available on the cluster. Organizations have two options:
+
+Fusion GitOps Quick Start (Recommended): Recommended for teams looking to establish a GitOps foundation in an IBM Fusion environment. This approach provides a guided path for installing and configuring OpenShift GitOps and aligns with the examples used throughout this article.
+
+Existing OpenShift GitOps (ArgoCD) Installation: Teams that already operate and manage their own ArgoCD environment can use the same deployment workflow described in this guide. Depending on your environment, you may need to adjust namespace references, permissions, and synchronization policies to align with existing standards and practices.
 
 ### Prerequisites
 
@@ -581,7 +591,7 @@ spec:
   source:
     repoURL: <your-fork>              # Your Git repository
     path: quickstarts/.../helm-charts # Path to Helm chart
-    targetRevision: master            # Git branch to track
+    targetRevision: <branch-name>  # Must match the branch created in Step 1 or if you are using default branch then keep master.
     helm:
       valueFiles:
         - environments/prod/values.yaml  # Environment-specific config
@@ -604,10 +614,10 @@ git add deploy/gitops/environments/prod/application.yaml
 git commit -m "Configure Fusion Developer Hub for production cluster"
 
 # Push to your forked repository (default: master branch)
-git push origin master
+git push origin <branch-name>
 ```
 
-> **Note:** By default, the Application CR uses `master` branch (`targetRevision: master`). If you want to use a custom branch, create your branch, commit there, and update `targetRevision` in the Application CR to match your branch name.
+> **Note:** This guide assumes you are working from the branch created in Step 1. By default, the Application CR uses `master` branch (`targetRevision: master`).Ensure the `targetRevision` field matches the branch that you push to your repository.
 
 **Step 6: Deploy to Your Cluster**
 
@@ -1218,13 +1228,17 @@ The quickstart deploys with **Guest Access** enabled by default for easy testing
 - ✅ **Guest Login**: Click "Enter" on the homepage to access immediately
 - **Note**: If you see a GitHub login error, this is expected. Use Guest access for testing.
 
+⚠️ Production Recommendation
+
+Guest access is enabled by default to simplify evaluation and onboarding. Before deploying to production, configure GitHub OAuth, OpenShift OAuth, or another supported identity provider and disable guest access to ensure appropriate authentication and access control.
+
 ### 4.2 Browse and Navigate Through Homepage
 
 The Developer Hub homepage is your central hub for accessing all Fusion AI resources, documentation, and tools.
 
 #### Welcome and Overview
 
-The homepage displays a welcome message with a link to the [Quickstart Guide](https://community.ibm.com/community/user/blogs/anushka-jaiswal/2026/05/29/quickstart-developer-hub-on-ibm-fusion-with-redhat) to help you get started.
+The homepage displays a welcome message with a link to the [Quickstart Guide](https://community.ibm.com/community/user/blogs/namita-singroha/2026/06/25/quickstart-fusion-developer-hub-via-gitops) to help you get started.
 
 #### Quick Access Sections
 

--- a/AI/quickstarts/fusion-developerhub/QUICKSTART.md
+++ b/AI/quickstarts/fusion-developerhub/QUICKSTART.md
@@ -509,7 +509,7 @@ Find the `repoURL` field (around line 14) and change it to point to your fork:
 spec:
   source:
     repoURL: https://github.com/<YOUR-USERNAME>/storage-fusion.git  # ← Change to your username
-    targetRevision: main  # Keep 'main' or change only if using a custom branch
+    targetRevision: master  # Keep 'master' or change only if using a custom branch
 ```
 
 **Example:** If your GitHub username is `john-doe`, change it to:
@@ -581,7 +581,7 @@ spec:
   source:
     repoURL: <your-fork>              # Your Git repository
     path: quickstarts/.../helm-charts # Path to Helm chart
-    targetRevision: main              # Git branch to track
+    targetRevision: master            # Git branch to track
     helm:
       valueFiles:
         - environments/prod/values.yaml  # Environment-specific config
@@ -603,11 +603,11 @@ git add deploy/gitops/environments/prod/application.yaml
 # Commit with descriptive message
 git commit -m "Configure Fusion Developer Hub for production cluster"
 
-# Push to your forked repository (default: main branch)
-git push origin main
+# Push to your forked repository (default: master branch)
+git push origin master
 ```
 
-> **Note:** By default, the Application CR uses `main` branch (`targetRevision: main`). If you want to use a custom branch, create your branch, commit there, and update `targetRevision` in the Application CR to match your branch name.
+> **Note:** By default, the Application CR uses `master` branch (`targetRevision: master`). If you want to use a custom branch, create your branch, commit there, and update `targetRevision` in the Application CR to match your branch name.
 
 **Step 6: Deploy to Your Cluster**
 
@@ -1156,8 +1156,8 @@ git add deploy/helm/environments/prod/values.yaml
 git commit -m "Customize Developer Hub homepage and catalog"
 
 # 2. Push to your repository
-# Replace 'main' with your branch name (e.g., 'main', 'master', 'develop')
-git push origin main
+# Replace 'master' with your branch name (e.g., 'main', 'master', 'develop')
+git push origin master
 
 # 3. ArgoCD will auto-sync within 3 minutes
 # Or force immediate sync:
@@ -1411,7 +1411,7 @@ cp values.yaml value-v1-june2026.yaml
 
 # Step 2: Pull latest changes
 cd storage-fusion/AI/quickstarts/fusion-developerhub
-git pull origin main
+git pull origin master
 
 # Step 3: Review changes (optional)
 helm diff upgrade fusion-developer-hub \
@@ -1480,7 +1480,7 @@ Pull the latest changes from IBM's upstream repository:
 
 ```bash
 cd storage-fusion/AI/quickstarts/fusion-developerhub
-git pull origin main
+git pull origin master
 ```
 
 **If you encounter merge conflicts** (this is normal if you customized the same fields IBM updated):
@@ -1508,7 +1508,7 @@ Archived version:
 - value-v1-june2026.yaml"
 
 # Push to your repository
-git push origin main
+git push origin master
 ```
 
 **Step 4: Deploy via ArgoCD**
@@ -1558,7 +1558,7 @@ cp value-v0-may2026.yaml values.yaml
 # Commit and push
 git add values.yaml
 git commit -m "rollback: Restore v0 (May 2026) configuration"
-git push origin main
+git push origin master
 
 # ArgoCD will auto-sync or manually sync in UI
 ```
@@ -1570,7 +1570,7 @@ git push origin main
 git revert HEAD
 
 # Push the revert
-git push origin main
+git push origin master
 ```
 
 For more details on version management, see [`deploy/helm/VERSION_MANAGEMENT.md`](deploy/helm/VERSION_MANAGEMENT.md).

--- a/AI/quickstarts/fusion-developerhub/README.md
+++ b/AI/quickstarts/fusion-developerhub/README.md
@@ -1,311 +1,116 @@
-# IBM Fusion Developer Hub - Operator-Based Deployment
+# IBM Fusion Developer Hub
 
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![OpenShift](https://img.shields.io/badge/OpenShift-4.12+-red.svg)](https://www.redhat.com/en/technologies/cloud-computing/openshift)
 [![Red Hat](https://img.shields.io/badge/Red%20Hat-Certified-red.svg)](https://www.redhat.com/)
 
-Production-ready deployment of Red Hat Developer Hub with IBM Fusion AI components on IBM Fusion platform. Supports both **Helm** (direct install) and **GitOps with ArgoCD** (Git-driven, automated) deployment models, using Kubernetes operators for enterprise-grade lifecycle management.
+Production-ready deployment of Red Hat Developer Hub (Backstage) with IBM Fusion AI components on IBM Fusion HCI. Installs and manages Red Hat Developer Hub and Crunchy PostgreSQL via Kubernetes operators, and supports both **Helm** and **GitOps with ArgoCD** deployment models.
 
 > **Platform**: IBM Fusion on Red Hat OpenShift 4.12+
-> See [QUICKSTART.md](QUICKSTART.md) for the full step-by-step deployment guide including GitOps setup, customization, upgrade, and troubleshooting.
+> **Full guide**: See [QUICKSTART.md](QUICKSTART.md) for step-by-step instructions covering Helm and GitOps deployment, configuration, customization, upgrade, and troubleshooting.
 
-## 🎯 Purpose
+## What You Get
 
-Deploy Red Hat Developer Hub on IBM Fusion with:
-- **Operator-Based Management** - Automated deployment, updates, and day-2 operations
-- **IBM Fusion AI Integration** - WatsonX, Granite models, and modernization tools
-- **High Availability** - Multi-instance PostgreSQL with automatic failover
-- **Enterprise Security** - RBAC, network policies, and pod security standards
+- **AI homepage** with automatic OpenShift AI model discovery (KServe InferenceServices cataloged every 30s)
+- **Pre-built AI app templates** — chatbot, RAG, code generation, object detection
+- **Software catalog** for Fusion components, NVIDIA blueprints, and custom services
+- **GitHub integration** — GitHub.com and GitHub Enterprise supported
+- **OIDC authentication** — OpenShift, Keycloak, or any OIDC-compliant provider
+- **High-availability PostgreSQL** — 3-instance Crunchy cluster with automatic failover and ODF backups
+- **Enterprise security** — RBAC, network policies, pod security standards, secret encryption
+- **GitOps ready** — ArgoCD Application CRs with sync-wave ordering included
 
-## ✨ Key Features
+## Repository Layout
 
-- 🎨 **Pre-configured Homepage** - IBM Fusion branding with automatic OpenShift AI model discovery
-- 🔐 **OIDC Authentication** - Integrated with IBM Fusion identity providers
-- 🤖 **AI-Powered Development** - WatsonX and Granite models for code generation
-- 🧩 **Pre-built AI Templates** - Chatbot, RAG, code generation, and object detection app templates
-- 🔗 **GitHub Integration** - Connect GitHub.com or GitHub Enterprise for SCM-backed catalog entities
-- 🔭 **RHOAI Model Registry** - Automatic cataloging of deployed KServe InferenceService models
-- 🔄 **Application Modernization** - Transformation Advisor and Mono2Micro
-- 📦 **Software Catalog** - Discover and manage Fusion components and NVIDIA blueprints
-- 🚀 **Self-Service Templates** - Rapid application creation with AI
-- 🔒 **Enterprise Security** - Production-grade security and compliance
-- 🔁 **GitOps Ready** - Native ArgoCD integration with sync-wave ordering
-
-## 🚀 Quick Start
-
-### Prerequisites
-
-- IBM Fusion platform on Red Hat OpenShift 4.12+
-- Helm 3.8+ and `oc` CLI tools
-- Cluster admin access for operator installation
-- For GitOps: ArgoCD / OpenShift GitOps installed
-
-### Option A — Deploy with Helm
-
-```bash
-# Clone repository
-git clone https://github.com/ProjectAbell/Fusion-AI.git
-cd Fusion-AI/quickstarts/fusion-developerhub
-
-# Deploy with guest access (demos/testing)
-helm upgrade --install fusion-hub ./deploy/helm \
-  -f examples/operator-fusion-guest-access-values.yaml \
-  --set global.wildcardDomain=apps.your-cluster.example.com \
-  --namespace fusion-dev-hub \
-  --create-namespace
-
-# Wait for deployment
-oc wait --for=condition=ready pod \
-  -l app.kubernetes.io/name=backstage \
-  -n fusion-dev-hub \
-  --timeout=600s
-
-# Get the route
-oc get route -n fusion-dev-hub
+```
+deploy/
+├── helm/                          # Helm chart
+│   ├── templates/                 # Kubernetes resource templates
+│   └── environments/
+│       ├── dev/values.yaml        # Development values
+│       ├── staging/values.yaml    # Staging values
+│       └── prod/values.yaml       # Production values
+└── gitops/
+    └── environments/
+        ├── dev/application.yaml   # ArgoCD Application CR — dev
+        ├── staging/application.yaml
+        └── prod/application.yaml  # ArgoCD Application CR — prod
 ```
 
-### Option B — Deploy with GitOps (ArgoCD)
+## Prerequisites
 
-```bash
-# Apply the ArgoCD Application CR for your target environment
-oc apply -f deploy/gitops/environments/dev/application.yaml
-```
+- IBM Fusion on Red Hat OpenShift 4.12+
+- `oc` CLI and Helm 3.8+
+- Cluster admin access
+- For GitOps: OpenShift GitOps (ArgoCD) installed
 
-ArgoCD will sync all resources in the correct order using sync-wave annotations. See [QUICKSTART.md — GitOps deployment](QUICKSTART.md#22-deploy-using-gitops) for full configuration steps.
+## Quick Start
 
-Access Developer Hub at: `https://backstage-fusion-hub-fusion-dev-hub.apps.your-cluster.example.com`
+Choose the deployment method that fits your workflow:
 
-## 📋 Deployment Examples
+| Method | When to use | Guide |
+|---|---|---|
+| **Helm** | Direct install, one-off deployment, local testing | [QUICKSTART.md — Deploy using Helm](QUICKSTART.md#21-deploy-using-helm) |
+| **GitOps (ArgoCD)** | Production, audit trail, Git-driven config management | [QUICKSTART.md — Deploy using GitOps](QUICKSTART.md#22-deploy-using-gitops) |
 
-### 1. Guest Access (Demos & Testing)
-**File**: `examples/operator-fusion-guest-access-values.yaml`
+Both methods deploy the same Helm chart. The values files under `deploy/helm/environments/` are used directly for Helm installs and referenced by the ArgoCD Application CRs for GitOps.
 
-```bash
-helm upgrade --install fusion-hub ./helm-charts/fusion-developer-hub \
-  -f examples/operator-fusion-guest-access-values.yaml \
-  --set global.wildcardDomain=apps.your-cluster.example.com \
-  --namespace fusion-dev-hub \
-  --create-namespace
-```
+> **First time?** Start with [QUICKSTART.md](QUICKSTART.md) — it covers prerequisites, required configuration changes (cluster domain, storage class), step-by-step deployment, verification, and access.
 
-**Features**:
-- No authentication required
-- Single PostgreSQL instance
-- Minimal resources
-- Perfect for demos and quick testing
+## Environment Values Files
 
-### 2. Development with OIDC
-**File**: `examples/operator-fusion-development-values.yaml`
+Pre-built values files are provided for dev, staging, and production. Each file has guest access enabled by default; OIDC fields are included as comments ready to fill in.
 
-```bash
-helm upgrade --install fusion-hub ./helm-charts/fusion-developer-hub \
-  -f examples/operator-fusion-development-values.yaml \
-  --set global.wildcardDomain=apps.your-cluster.example.com \
-  --namespace fusion-dev-hub \
-  --create-namespace
-```
+| Environment | File | Notes |
+|---|---|---|
+| Development | `deploy/helm/environments/dev/values.yaml` | Guest access, minimal resources |
+| Staging | `deploy/helm/environments/staging/values.yaml` | Guest access or OIDC |
+| Production | `deploy/helm/environments/prod/values.yaml` | HA PostgreSQL, ODF backups, OIDC recommended |
 
-**Features**:
-- OIDC authentication enabled
-- IBM Fusion AI components
-- Single PostgreSQL instance
-- Development-optimized resources
-
-### 3. Production with High Availability
-**File**: `examples/operator-fusion-production-values.yaml`
-
-```bash
-helm upgrade --install fusion-hub ./helm-charts/fusion-developer-hub \
-  -f examples/operator-fusion-production-values.yaml \
-  --set global.wildcardDomain=apps.your-cluster.example.com \
-  --namespace fusion-hub \
-  --create-namespace
-```
-
-**Features**:
-- OIDC authentication required
-- 3-instance PostgreSQL cluster with automatic failover
-- Automated backups to S3
-- Production-grade resources and security
-- Network policies and resource quotas
-
-## 🏗️ Architecture
-
-### Operator-Based Deployment
+## Architecture
 
 ```
 ┌─────────────────────────────────────────────────────────┐
 │                    IBM Fusion Platform                   │
-├─────────────────────────────────────────────────────────┤
-│                                                           │
+│                                                          │
 │  ┌──────────────────┐      ┌──────────────────┐        │
 │  │  RHDH Operator   │      │ Postgres Operator│        │
-│  │  (AllNamespaces) │      │  (AllNamespaces) │        │
 │  └────────┬─────────┘      └────────┬─────────┘        │
-│           │                         │                    │
-│           ▼                         ▼                    │
+│           │ manages                  │ manages           │
+│           ▼                          ▼                   │
 │  ┌──────────────────┐      ┌──────────────────┐        │
 │  │   Backstage CR   │      │ PostgresCluster  │        │
-│  │  (fusion-hub)    │◄────►│   (3 instances)  │        │
+│  │  (3 replicas)    │◄────►│  (3 instances)   │        │
 │  └──────────────────┘      └──────────────────┘        │
 │           │                                              │
 │           ▼                                              │
-│  ┌──────────────────────────────────────────┐          │
-│  │        Developer Hub Pods                 │          │
-│  │  ┌────────┐  ┌────────┐  ┌────────┐     │          │
-│  │  │ RHDH-1 │  │ RHDH-2 │  │ RHDH-3 │     │          │
-│  │  └────────┘  └────────┘  └────────┘     │          │
-│  └──────────────────────────────────────────┘          │
-│                                                           │
+│  OpenShift AI (optional) — model discovery               │
 └─────────────────────────────────────────────────────────┘
 ```
 
-### Components
+## Documentation
 
-- **Red Hat Developer Hub Operator** - Manages Backstage lifecycle
-- **Crunchy PostgreSQL Operator** - Manages database cluster
-- **Backstage CR** - Developer Hub instance configuration
-- **PostgresCluster CR** - High-availability database
+| Topic | Link |
+|---|---|
+| Full deployment guide | [QUICKSTART.md](QUICKSTART.md) |
+| Helm blog post | [IBM Community — Fusion Developer Hub Quickstart](https://community.ibm.com/community/user/blogs/anushka-jaiswal/2026/05/29/quickstart-developer-hub-on-ibm-fusion-with-redhat) |
+| Homepage customization | [QUICKSTART.md — Section 3.1](QUICKSTART.md#31-customize-homepage) |
+| GitHub integration | [QUICKSTART.md — Section 3.3](QUICKSTART.md#33-configure-github-integration) |
+| RHOAI model registry | [QUICKSTART.md — Section 3.4](QUICKSTART.md#34-rhoai-model-registry-integration) |
+| Upgrade & rollback | [QUICKSTART.md — Section 5](QUICKSTART.md#upgrade) |
+| Troubleshooting | [QUICKSTART.md — Troubleshooting](QUICKSTART.md#troubleshooting) |
 
-## 📚 Documentation
+## Contributing
 
-- **[Deployment Guide](docs/getting-started/operator-getting-started.md)** - Complete deployment instructions with all options
-- **[Homepage Customization](docs/homepage-customization.md)** - Customize the homepage
-- **[Adding Fusion Services](docs/adding-fusion-services.md)** - Integrate Fusion AI services
-- **[OIDC Providers](docs/getting-started/oidc-providers.md)** - Configure authentication
-- **[Troubleshooting](docs/troubleshooting/README.md)** - Common issues and solutions
-
-## 🔧 Configuration
-
-### Global Settings
-
-```yaml
-global:
-  wildcardDomain: apps.your-cluster.example.com  # Required
-  toolsImage: quay.io/openshift/origin-cli:latest
-  modelsNamespace: maas-models
-```
-
-### Authentication
-
-```yaml
-developerHub:
-  auth:
-    guest:
-      enabled: true  # For demos only
-    oidc:
-      enabled: true  # Production
-      metadataUrl: "https://your-oidc-provider/.well-known/openid-configuration"
-```
-
-### Database
-
-```yaml
-developerHub:
-  database:
-    useOperator: true
-    instances: 3  # High availability
-    backup:
-      enabled: true
-      useODF: true  # IBM Fusion object storage
-```
-
-## 🛠️ Operations
-
-### Check Deployment Status
-
-```bash
-# Check operators
-oc get csv -n rhdh-operator
-oc get csv -n postgres-operator
-
-# Check Developer Hub
-oc get backstage -n fusion-dev-hub
-oc get pods -n fusion-dev-hub
-
-# Check PostgreSQL
-oc get postgrescluster -n fusion-dev-hub
-```
-
-### View Logs
-
-```bash
-# Developer Hub logs
-oc logs -n fusion-dev-hub -l app.kubernetes.io/name=backstage -f
-
-# PostgreSQL logs
-oc logs -n fusion-dev-hub -l postgres-operator.crunchydata.com/cluster=fusion-postgres -f
-```
-
-### Upgrade
-
-```bash
-helm upgrade fusion-hub ./deploy/helm \
-  -f examples/operator-fusion-production-values.yaml \
-  --set global.wildcardDomain=apps.your-cluster.example.com \
-  --namespace fusion-hub
-```
-
-For GitOps upgrades (update chart version or values in Git, then sync via ArgoCD) and rollback procedures, see [QUICKSTART.md — Upgrade](QUICKSTART.md#upgrade).
-
-## 🔍 Troubleshooting
-
-### Common Issues
-
-**Operators not installing**
-```bash
-# Check operator subscriptions
-oc get subscription -n rhdh-operator
-oc get subscription -n postgres-operator
-```
-
-**PostgreSQL not ready**
-```bash
-# Check cluster status
-oc describe postgrescluster -n fusion-dev-hub
-```
-
-**Developer Hub not starting**
-```bash
-# Check Backstage CR
-oc describe backstage -n fusion-dev-hub
-```
-
-See [Troubleshooting Guide](docs/troubleshooting/README.md) for detailed solutions.
-
-## 📊 Monitoring
-
-The deployment includes:
-- Operator metrics and health checks
-- PostgreSQL cluster monitoring
-- Developer Hub application metrics
-- Integration with IBM Fusion monitoring stack
-
-## 🔒 Security
-
-- **Pod Security Standards** - Restricted profile enforced
-- **Network Policies** - Controlled ingress/egress
-- **RBAC** - Least privilege access
-- **Secrets Management** - Operator-managed secrets
-- **Resource Quotas** - Prevent resource exhaustion
-
-## 🤝 Contributing
-
-Contributions welcome! Please:
 1. Fork the repository
 2. Create a feature branch
 3. Submit a pull request
 
-## 📄 License
+## License
 
-Apache License 2.0 - See [LICENSE](LICENSE) for details
+Apache License 2.0 — see [LICENSE](LICENSE) for details.
 
-## 🆘 Support
+## Support
 
-- **Documentation**: [docs/](docs/)
-- **Issues**: [GitHub Issues](https://github.com/ProjectAbell/Fusion-AI/issues)
+- **Issues**: [GitHub Issues](https://github.com/IBM/storage-fusion/issues)
 - **IBM Fusion Support**: Contact your IBM Fusion support team
-
----
-
-**Made with Bob** 🤖 | **Powered by IBM Fusion AI**

--- a/AI/quickstarts/fusion-developerhub/README.md
+++ b/AI/quickstarts/fusion-developerhub/README.md
@@ -4,10 +4,10 @@
 [![OpenShift](https://img.shields.io/badge/OpenShift-4.12+-red.svg)](https://www.redhat.com/en/technologies/cloud-computing/openshift)
 [![Red Hat](https://img.shields.io/badge/Red%20Hat-Certified-red.svg)](https://www.redhat.com/)
 
-Production-ready Helm chart for deploying Red Hat Developer Hub with IBM Fusion AI components on IBM Fusion platform using Kubernetes operators.
+Production-ready deployment of Red Hat Developer Hub with IBM Fusion AI components on IBM Fusion platform. Supports both **Helm** (direct install) and **GitOps with ArgoCD** (Git-driven, automated) deployment models, using Kubernetes operators for enterprise-grade lifecycle management.
 
 > **Platform**: IBM Fusion on Red Hat OpenShift 4.12+
-> This chart uses operator-based deployment for enterprise-grade reliability, high availability, and automated lifecycle management.
+> See [QUICKSTART.md](QUICKSTART.md) for the full step-by-step deployment guide including GitOps setup, customization, upgrade, and troubleshooting.
 
 ## 🎯 Purpose
 
@@ -19,24 +19,28 @@ Deploy Red Hat Developer Hub on IBM Fusion with:
 
 ## ✨ Key Features
 
-- 🎨 **Pre-configured Homepage** - IBM Fusion branding with AI capabilities
+- 🎨 **Pre-configured Homepage** - IBM Fusion branding with automatic OpenShift AI model discovery
 - 🔐 **OIDC Authentication** - Integrated with IBM Fusion identity providers
 - 🤖 **AI-Powered Development** - WatsonX and Granite models for code generation
+- 🧩 **Pre-built AI Templates** - Chatbot, RAG, code generation, and object detection app templates
+- 🔗 **GitHub Integration** - Connect GitHub.com or GitHub Enterprise for SCM-backed catalog entities
+- 🔭 **RHOAI Model Registry** - Automatic cataloging of deployed KServe InferenceService models
 - 🔄 **Application Modernization** - Transformation Advisor and Mono2Micro
-- 📦 **Software Catalog** - Discover and manage Fusion components
+- 📦 **Software Catalog** - Discover and manage Fusion components and NVIDIA blueprints
 - 🚀 **Self-Service Templates** - Rapid application creation with AI
 - 🔒 **Enterprise Security** - Production-grade security and compliance
+- 🔁 **GitOps Ready** - Native ArgoCD integration with sync-wave ordering
 
 ## 🚀 Quick Start
 
 ### Prerequisites
 
 - IBM Fusion platform on Red Hat OpenShift 4.12+
-- Helm 3.8+
-- `oc` CLI tools
+- Helm 3.8+ and `oc` CLI tools
 - Cluster admin access for operator installation
+- For GitOps: ArgoCD / OpenShift GitOps installed
 
-### Deploy Developer Hub
+### Option A — Deploy with Helm
 
 ```bash
 # Clone repository
@@ -44,7 +48,7 @@ git clone https://github.com/ProjectAbell/Fusion-AI.git
 cd Fusion-AI/quickstarts/fusion-developerhub
 
 # Deploy with guest access (demos/testing)
-helm upgrade --install fusion-hub ./helm-charts/fusion-developer-hub \
+helm upgrade --install fusion-hub ./deploy/helm \
   -f examples/operator-fusion-guest-access-values.yaml \
   --set global.wildcardDomain=apps.your-cluster.example.com \
   --namespace fusion-dev-hub \
@@ -59,6 +63,15 @@ oc wait --for=condition=ready pod \
 # Get the route
 oc get route -n fusion-dev-hub
 ```
+
+### Option B — Deploy with GitOps (ArgoCD)
+
+```bash
+# Apply the ArgoCD Application CR for your target environment
+oc apply -f deploy/gitops/environments/dev/application.yaml
+```
+
+ArgoCD will sync all resources in the correct order using sync-wave annotations. See [QUICKSTART.md — GitOps deployment](QUICKSTART.md#22-deploy-using-gitops) for full configuration steps.
 
 Access Developer Hub at: `https://backstage-fusion-hub-fusion-dev-hub.apps.your-cluster.example.com`
 
@@ -227,11 +240,13 @@ oc logs -n fusion-dev-hub -l postgres-operator.crunchydata.com/cluster=fusion-po
 ### Upgrade
 
 ```bash
-helm upgrade fusion-hub ./helm-charts/fusion-developer-hub \
+helm upgrade fusion-hub ./deploy/helm \
   -f examples/operator-fusion-production-values.yaml \
   --set global.wildcardDomain=apps.your-cluster.example.com \
   --namespace fusion-hub
 ```
+
+For GitOps upgrades (update chart version or values in Git, then sync via ArgoCD) and rollback procedures, see [QUICKSTART.md — Upgrade](QUICKSTART.md#upgrade).
 
 ## 🔍 Troubleshooting
 

--- a/AI/quickstarts/fusion-developerhub/README.md
+++ b/AI/quickstarts/fusion-developerhub/README.md
@@ -4,7 +4,7 @@
 [![OpenShift](https://img.shields.io/badge/OpenShift-4.12+-red.svg)](https://www.redhat.com/en/technologies/cloud-computing/openshift)
 [![Red Hat](https://img.shields.io/badge/Red%20Hat-Certified-red.svg)](https://www.redhat.com/)
 
-Production-ready deployment of Red Hat Developer Hub (Backstage) with IBM Fusion AI components on IBM Fusion HCI. Installs and manages Red Hat Developer Hub and Crunchy PostgreSQL via Kubernetes operators, and supports both **Helm** and **GitOps with ArgoCD** deployment models.
+A unified developer portal for AI-first development on IBM Fusion HCI. Provides centralized access to AI resources, documentation, NVIDIA blueprints, Fusion quickstarts, and self-service application templates — deployed and managed via Kubernetes operators with support for both **Helm** and **GitOps with ArgoCD** deployment models.
 
 > **Platform**: IBM Fusion on Red Hat OpenShift 4.12+
 > **Full guide**: See [QUICKSTART.md](QUICKSTART.md) for step-by-step instructions covering Helm and GitOps deployment, configuration, customization, upgrade, and troubleshooting.

--- a/AI/quickstarts/fusion-developerhub/deploy/gitops/environments/dev/application.yaml
+++ b/AI/quickstarts/fusion-developerhub/deploy/gitops/environments/dev/application.yaml
@@ -14,7 +14,7 @@ spec:
   source:
     repoURL: https://github.com/your-org/your-repo.git #IMPORTANT: Replace with your repo URL
     path: AI/quickstarts/fusion-developerhub/deploy/helm
-    targetRevision: main # Replace with your target branch or tag
+    targetRevision: master # Replace with your target branch or tag
     helm:
       valueFiles:
         - values.yaml

--- a/AI/quickstarts/fusion-developerhub/deploy/gitops/environments/prod/application.yaml
+++ b/AI/quickstarts/fusion-developerhub/deploy/gitops/environments/prod/application.yaml
@@ -12,7 +12,7 @@ spec:
   source:
     repoURL: https://github.com/your-org/your-repo.git #IMPORTANT: Replace with your repo URL
     path: AI/quickstarts/fusion-developerhub/deploy/helm
-    targetRevision: main # Replace with your target branch or tag
+    targetRevision: master # Replace with your target branch or tag
     helm:
       valueFiles:
         - values.yaml

--- a/AI/quickstarts/fusion-developerhub/deploy/gitops/environments/staging/application.yaml
+++ b/AI/quickstarts/fusion-developerhub/deploy/gitops/environments/staging/application.yaml
@@ -13,7 +13,7 @@ spec:
   source:
     repoURL: https://github.com/your-org/your-repo.git #IMPORTANT: Replace with your repo URL
     path: AI/quickstarts/fusion-developerhub/deploy/helm
-    targetRevision: main # Replace with your target branch or tag
+    targetRevision: master # Replace with your target branch or tag
     helm:
       valueFiles:
         - values.yaml

--- a/AI/quickstarts/fusion-developerhub/deploy/helm/templates/developerhub-instance.yaml
+++ b/AI/quickstarts/fusion-developerhub/deploy/helm/templates/developerhub-instance.yaml
@@ -118,7 +118,6 @@ metadata:
 spec:
   # Allow multiple retries with exponential backoff
   backoffLimit: 20
-  ttlSecondsAfterFinished: 1800
   template:
     metadata:
       labels:
@@ -295,7 +294,6 @@ metadata:
     argocd.argoproj.io/sync-options: Force=true,Replace=true
 spec:
   backoffLimit: 10
-  ttlSecondsAfterFinished: 1800
   template:
     metadata:
       labels:

--- a/AI/quickstarts/fusion-developerhub/deploy/helm/templates/developerhub-operator.yaml
+++ b/AI/quickstarts/fusion-developerhub/deploy/helm/templates/developerhub-operator.yaml
@@ -81,7 +81,6 @@ metadata:
     argocd.argoproj.io/sync-wave: "40"
     argocd.argoproj.io/sync-options: Force=true,Replace=true
 spec:
-  ttlSecondsAfterFinished: 3600
   template:
     metadata:
       labels:

--- a/AI/quickstarts/fusion-developerhub/deploy/helm/templates/namespace-labeler.yaml
+++ b/AI/quickstarts/fusion-developerhub/deploy/helm/templates/namespace-labeler.yaml
@@ -20,7 +20,6 @@ metadata:
     argocd.argoproj.io/sync-wave: "10"
     argocd.argoproj.io/sync-options: Force=true,Replace=true
 spec:
-  ttlSecondsAfterFinished: 3600 
   template:
     metadata:
       labels:

--- a/AI/quickstarts/fusion-developerhub/deploy/helm/templates/operator-check.yaml
+++ b/AI/quickstarts/fusion-developerhub/deploy/helm/templates/operator-check.yaml
@@ -19,7 +19,6 @@ metadata:
     argocd.argoproj.io/sync-options: Force=true,Replace=true
     # helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 spec:
-  ttlSecondsAfterFinished: 3600
   backoffLimit: 1
   template:
     metadata:

--- a/AI/quickstarts/fusion-developerhub/deploy/helm/templates/postgres-operator.yaml
+++ b/AI/quickstarts/fusion-developerhub/deploy/helm/templates/postgres-operator.yaml
@@ -85,7 +85,6 @@ metadata:
     argocd.argoproj.io/sync-wave: "40"
     argocd.argoproj.io/sync-options: Force=true,Replace=true
 spec:
-  ttlSecondsAfterFinished: 3600
   template:
     metadata:
       labels:

--- a/AI/quickstarts/fusion-developerhub/deploy/helm/templates/wait-for-crds.yaml
+++ b/AI/quickstarts/fusion-developerhub/deploy/helm/templates/wait-for-crds.yaml
@@ -19,7 +19,6 @@ metadata:
     argocd.argoproj.io/sync-wave: "40"
     argocd.argoproj.io/sync-options: Force=true,Replace=true
 spec:
-  ttlSecondsAfterFinished: 3600
   backoffLimit: 3
   template:
     metadata:


### PR DESCRIPTION
This PR has following changes:

- Removed ttlSecondsAfterFinished from all 7 setup Jobs across the helm chart. Jobs were being deleted by TTL (1800–3600s) after completion, causing ArgoCD to permanently show the application as OutOfSync. With no TTL, completed jobs stay on the cluster and ArgoCD remains InSync. Upgrades are safe — existing Force=true,Replace=true annotations handle job recreation on spec changes.

- Updated README.md to mention GitOps/ArgoCD as a deployment option alongside Helm, added missing features (pre-built AI templates, GitHub integration, RHOAI model registry), and fixed stale helm chart paths.

- Updated default targetRevision from main to master in ArgoCD Application CRs for dev/staging/prod environments.