### PR TITLE
CAS: Local Data Caching 1.1.5 Updates & Migration

### DIFF
--- a/CAS/local-data-caching/README.md
+++ b/CAS/local-data-caching/README.md
@@ -2,29 +2,32 @@
 
 This tool deploys a configuration of IBM Fusion services that enable local caching of data from remote S3 buckets for ingestion by CAS. This is achieved by setting up an IBM Storage Scale Container Native (formerly known as CNSA) local Scale cluster on OpenShift Container Platform using local Data Foundation (DF) RBD volumes as backing storage devices.
 
-The scripts in these directories work against both Fusion SDS 2.12 and Fusion HCI 2.12.
+The scripts in these directories work against both Fusion SDS and Fusion HCI.
 
 ---
 
-## Requirements
+## Cluster Requirements
 
-* OpenShift version **4.17** or higher, **4.20** is recommended
-* IBM Fusion SDS or HCI **2.12** or higher
+* OpenShift version **4.18** or higher, **4.20** is recommended
+* IBM Fusion SDS or HCI **2.12** or higher (default install target: **2.13**)
 * **Cluster admin access**
 * At least **3 worker nodes** OR **Compact cluster** with at least one local disk per node, recommended at least 1TB disks
 * At least 1 node with [supported GPUs](https://www.ibm.com/docs/en/fusion-software/2.12.0?topic=prerequisites-system-requirements#systemrequirements__table_xpm_ddx_rgc)
 
-### Prerequisites
+### Required System Tools
 
-* Linux host with connectivity to the OCP API
-* `bash`
+* Host with connectivity to the OCP API
+* `bash` or `zsh`
 * `oc` client
-* `envsubst` CLI utility
+* `envsubst`
+* `yq` — used by `setup-data-cache.sh`
+* `jq` — used by `setup-data-cache.sh` and `cleanup-data-cache.sh`
+* `curl` — used by `cleanup-data-cache.sh` to download the CAS cleanup script if not already present locally
 
 ## Setup Script Usage
 
 ```bash
-$ ./bin/setup-data-cache.sh [--filesystem-name <name>] [--filesystem-capacity <Gi>]
+./bin/setup-data-cache.sh [--filesystem-name <name>] [--filesystem-capacity <Gi>]
 ```
 
 ### Optional Inputs
@@ -32,19 +35,16 @@ $ ./bin/setup-data-cache.sh [--filesystem-name <name>] [--filesystem-capacity <G
 | Flag                    | Description                | Default    |
 | ----------------------- | -------------------------- | ---------- |
 | `--filesystem-name`     | Name of the filesystem     | `cache-fs` |
-| `--filesystem-capacity` | Capacity of the filesystem as [Kubernetes Quantities](https://kubernetes.io/docs/reference/kubernetes-api/common-definitions/quantity/) (e.g. Gi, Ti, G, T) | `250Gi`   |
+| `--filesystem-capacity` | Capacity of the filesystem as [Kubernetes Quantities](https://kubernetes.io/docs/reference/kubernetes-api/common-definitions/quantity/) (e.g. Gi, Ti, G, T) | `256Gi` |
 
 ### Configuration Parameters
 
 The script uses additional configuration parameters that can be modified either in the [config/config.env](./config/config.env) file or by exporting them in the shell prior to running the script. These include, among others:
 
-* **FUSION_VERSION** – Version of Fusion to install (controls the CatalogSource image) (default: `2.12.0`)
+* **FUSION_VERSION** – Version of Fusion to install (controls the CatalogSource image) (default: `2.13.0`)
 * **FUSION_NAMESPACE** – Namespace where the Fusion operator will be installed (default: `ibm-spectrum-fusion-ns`)
 * **INSTALL_STRATEGY** – Install strategy for the operator: `Automatic` or `Manual` (default: `Automatic`)
-* **LOCAL_STORAGE_PROJECT** – Project name for PVCs (default: `local-disk-as-pv`)
-
-> [!NOTE]
-> Some platforms (VMWare, Nutanix, Hyper-V, etc.) do not properly present the drives to OpenShift Data Foundation as a flash drive (i.e. SSD or "non-rotational"). It is recommended to set the environment variable `CONVERT_HDD_TO_SSD` to convert rotational (HDD) disks to SSD on worker nodes during setup. For more information, including how to make this change persistent across node reboots, see [this Red Hat Knowledgebase article](https://access.redhat.com/articles/6547891).
+* **ODF_ALLOW_ROTATIONAL** – Set to `true` to allow rotational (HDD) disks to be used as ODF backing storage. Some platforms (VMware, Nutanix, Hyper-V, etc.) do not properly present drives as non-rotational; enabling this bypasses that check. (default: `false`)
 
 ### What the Script Does
 
@@ -59,7 +59,7 @@ Before launching the deployment, the script verifies:
 
 #### 2. Fusion Deployment
 
-Applies the Spectrum Fusion Custom Resource (CR). For Fusion SDS, it will also install the IBM Fusion Operator (`isf-operator`) if it is not present.
+If Fusion is not installed, the script will install the IBM Fusion Operator (`isf-operator`) and apply the Spectrum Fusion Custom Resource (CR).
 
 #### 3. Deploying Data Foundation in Provider Mode
 
@@ -68,238 +68,61 @@ Once deployed, DF is configured with:
 
 * **Worker node labeling** – Applies required labels to all worker nodes.
 * **LocalVolumeSet creation** – Instantiates a `LocalVolumeSet` for the cluster.
-* **StorageCluster provisioning** – Creates a `StorageCluster` with a capacity that looks for and uses all local disks as backing stores.
+* **StorageCluster provisioning** – Creates a `StorageCluster` that uses all available local disks as backing stores.
 
-#### 4. Creating DaemonSets with Assigned PVCs
+#### 4. Scale Container Native Configuration
 
-Deploys a DaemonSet using PersistentVolumeClaims (PVCs) provisioned from a custom RBD StorageClass. This DaemonSet runs on all nodes that will run Scale Container Native and mounts the RBD volumes as local block devices.
-
-#### 5. Mapping Device IDs to LocalDisk PVCs
-
-The script automates mapping between **RBD block devices** and **PersistentVolumeClaims (PVCs)**:
-
-* **Collect RBD devices** – Retrieves all RBD devices from the `csi-rbdplugin` container and records the node on which each pod runs.
-* **Extract PV metadata** – For each PVC, locates its PV and reads the `pool` and `imageName` fields.
-* **Match devices** – Uses the `pool` and `imageName` values to identify the corresponding device name in the RBD list.
-
-#### 6. Scale Container Native Configuration
-
-* **Service installation** – For Fusion SDS, patches the Spectrum Fusion CR to install the Global Data Platform (GDP) service. For Fusion HCI, installs the `scalemanager` Fusion service.
-* **Scale cluster creation** – Creates a Scale `Cluster` CR, dynamically retrieving the cluster’s base domain and subdomain from the OpenShift environment to instantiate the initial Spectrum Scale cluster using the root domain.
+* **Service installation** – Installs the Scale service and operator.
+  * For Fusion 2.12, it patches the `SpectrumFusion` CR to enable Global Data Platform (GDP).
+  * For Fusion 2.13+ with DF 4.21+, Scale is managed by DF and the operator is created when the first `Cluster` CR is detected.
+* **Scale cluster creation** – Creates a Scale `Cluster` CR, dynamically retrieving the cluster's base domain and subdomain from the OpenShift environment.
 * **Cluster verification** – Confirms the Scale Cluster is in a healthy, operational state.
-* **Device-ID patch** – Applies a regex-formatted device ID to the `Cluster` CR.
-* **LocalDisk creation** – Generates `LocalDisk` CRs based on the device-ID and node-name mapping.
-* **Validation** – Ensures each `LocalDisk` reaches the *Ready* state and is shared.
-* **Filesystem provisioning** – Creates a Scale `Filesystem` CR that utilizes the created `LocalDisks`.
-* **Health check** – Verifies the `Filesystem`’s health and that it reaches the *Established* status.
-* **Usage verification** – Confirms that the `LocalDisks` are actively used by the `Filesystem`.
-* **Set up AFM** - Configures the Scale cluster for AFM by applying the appropriate node labels.
 
 > [!NOTE]
-> Installing GDP (if missing) triggers an MCO rollout on all worker nodes to deploy the kernel-devel package, which may take some time. Should the script time out or if connectivity is lost, the script can be safely re-run and will pick up where it left off.
+> Creating a Scale Cluster triggers a rollout on all worker nodes to build and mount the GPFS kernel module, which can take some time depending on the number of nodes in the cluster. Should the script time out or if connectivity is lost, the script can be safely re-run and will pick up where it left off.
 
-#### 7. Deploying CAS with Scale Container Native local Filesystem
+#### 5. Deploying CAS with Scale Container Native Local Filesystem
 
-Finally, the script will install and configure CAS.
+The script will install and configure CAS with a local Scale Filesystem service as an AFM cache.
 
-* **CAS installation** - Creates the Fusion Service Definition to deploy the `cas-operator` and `CasInstall` CR.
-* **Configure Kafka Watch** - Automatically configures the Kafka Watch for the Scale cluster.
+* **Set up AFM** – Configures the Scale cluster for AFM by applying the appropriate node labels.
+* **Filesystem creation** – Creates the Scale `Filesystem` CR.
+* **Configure Kafka Watch** – Automatically configures the Kafka Watch for the Scale cluster.
+* **CAS installation** – Creates the Fusion Service Definition to deploy the `cas-operator` and `CasInstall` CR.
 
-## Verification Script Usage
+## Migration Script Usage
+
+The migration is required when upgrading from CAS 1.1.4 to CAS 1.1.5 if you have an existing local Filesystem cache configured in CAS 1.1.4.
 
 ```bash
-test/verify.sh
+./bin/migrate-data-cache.sh --migration-phase <phase> [OPTIONS]
 ```
 
-Example output:
-```bash
-$ ./tests/verify.sh
-🔍 Running IBM Spectrum Scale Health Checks...
-✅ StorageCluster is Ready
-✅ Spectrum Scale Daemon is Available
-✅ All Daemon pods running (6/6)
-✅ Spectrum Scale Daemon is Healthy
-✅ All pods are Running/Completed in ibm-spectrum-scale namespace
-✅ All LocalDisks are shared & Healthy
-✅ Filesystem is Healthy
-🔧 Deploying test PVC...
-⏳ Waiting for PVC 'cache-fs-test-pvc' to become Bound...
-⏳ Attempt 1/6 → PVC Status: Pending
-🎯 PVC Test: PASS
-🧹 Cleanup: Removing test PVC and Namespace...
-✅ Cleanup Complete.
-```
+Run `./bin/migrate-data-cache.sh --help` for the full flag and environment variable reference.
+
+See [docs/MIGRATION.md](docs/MIGRATION.md) for the complete migration guide including phases, workflow, and environment variables.
 
 ## Cleanup Script
 
+Removes the data cache deployment. A required action flag determines the scope of cleanup.
+
 ```bash
-$ ./bin/cleanup-data-cache.sh [--filesystem-name <name>]
+./bin/cleanup-data-cache.sh <ACTION> [--filesystem-name <name>]
 ```
+
+| Action      | Scope |
+| ----------- | ----- |
+| `--cas`     | CAS only |
+| `--cnsa`    | CAS and Scale Container Native |
+| `--df`      | CAS, Scale Container Native, and Data Foundation |
+| `--all`     | CAS, Scale Container Native, Data Foundation, and Fusion (SDS only) |
+
+Run `./bin/cleanup-data-cache.sh --help` for the full reference.
 
 ---
----
 
-## Troubleshooting
+## Further Reading
 
-### Image Pull Errors
-
-* Check pod events for failures.
-* Verify manifests for IDMS/ITMS issues.
-* Ensure pull secrets are valid.
-
-> [!NOTE]
-> The image `registry.access.redhat.com/ubi8/ubi` must be **mirrored** into the internal registry and **IDMS/ITMS** must be configured. Missing mirroring will cause deployment failures in restricted networks.
-
-<details>
-<summary><strong>Show Offline / Internal Registry Configuration</strong></summary>
-
-<br>
-
-Log in to the IBM Entitled Container Registry by using the IBM entitlement key:
-
-```bash
-docker login cp.icr.io -u cp -p <your entitlement key>
-```
-
-> [!NOTE]
-> Ensure that your entitlement key for IBM Fusion contains the correct entitlement.
-
-Set the following environment variables:
-
-```bash
-export LOCAL_ISF_REGISTRY="<Your enterprise registry host>:<port>"
-export LOCAL_ISF_REPOSITORY="<Your image path>"
-export TARGET_PATH="$LOCAL_ISF_REGISTRY/$LOCAL_ISF_REPOSITORY"
-```
-
-Run the following commands to create files with the properly replaced variables:
-
-```bash
-$ cat << EOF > isf-mirror-idms.yaml
-apiVersion: config.openshift.io/v1
-kind: ImageDigestMirrorSet
-metadata:
-  name: isf-mirror-idms
-spec:
-  imageDigestMirrors:
-  - mirrors:
-      - $TARGET_PATH/cp
-    source: icr.io/cp
-  - mirrors:
-      - $TARGET_PATH/cpopen
-    source: icr.io/cpopen
-  - mirrors:
-      - $TARGET_PATH/cp
-    source: cp.icr.io/cp
-  - mirrors:
-      - $TARGET_PATH/cpopen
-    source: cp.icr.io/cpopen
-EOF
-
-$ oc apply -f isf-mirror-idms.yaml
-```
-
-```bash
-$ cat << EOF > isf-gdp-idms.yaml
-apiVersion: config.openshift.io/v1
-kind: ImageDigestMirrorSet
-metadata:
-  name: isf-gdp-idms
-spec:
-  imageDigestMirrors:
-  - mirrors:
-      - $TARGET_PATH/cp/gpfs
-    source: cp.icr.io/cp/gpfs
-  - mirrors:
-      - $TARGET_PATH/cp/spectrum/scale
-    source: cp.icr.io/cp/spectrum/scale
-EOF
-
-$ oc apply -f isf-gdp-idms.yaml
-```
-
-```bash
-$ cat << EOF > isf-fdf-idms.yaml
-apiVersion: config.openshift.io/v1
-kind: ImageDigestMirrorSet
-metadata:
-  labels:
-    operators.openshift.org/catalog: "true"
-  name: isf-fdf-idms
-spec:
-  imageDigestMirrors:
-  - mirrors:
-    - $TARGET_PATH/openshift4
-    source: registry.redhat.io/openshift4
-  - mirrors:
-    - $TARGET_PATH/redhat
-    source: registry.redhat.io/redhat
-  - mirrors:
-    - $TARGET_PATH/rhel9
-    source: registry.redhat.io/rhel9
-  - mirrors:
-    - $TARGET_PATH/rhel8
-    source: registry.redhat.io/rhel8
-  - mirrors:
-    - $TARGET_PATH/cp/df
-    source: cp.icr.io/cp/df
-  - mirrors:
-    - $TARGET_PATH/cp/ibm-ceph
-    source: cp.icr.io/cp/ibm-ceph
-  - mirrors:
-    - $TARGET_PATH/odf4
-    source: registry.redhat.io/odf4
-  - mirrors:
-    - $TARGET_PATH/lvms4
-    source: registry.redhat.io/lvms4
-EOF
-
-$ oc apply -f isf-fdf-idms.yaml
-```
-
-```bash
-$ cat << EOF > isf-fdf-itms.yaml
-apiVersion: config.openshift.io/v1
-kind: ImageTagMirrorSet
-metadata:
-  name: isf-fdf-itms
-spec:
-  imageTagMirrors:
-    - mirrors:
-        - $TARGET_PATH/cpopen/isf-data-foundation-catalog
-      source: icr.io/cpopen/isf-data-foundation-catalog
-      mirrorSourcePolicy: AllowContactingSource
-EOF
-
-$ oc apply -f isf-fdf-itms.yaml
-```
-
-</details>
-
-### Leftover Ceph metadata
-
-* If StorageCluster is stuck in `Provisioning` phase (e.g., `failed to get device already provisioned by ceph-volume`), clean old Ceph metadata: [Red Hat Solution 7115651](https://access.redhat.com/solutions/7115651).
-* After cleanup, wait for the storage cluster to reach `Ready` phase. Inspect with the following command:
-  ```bash
-  oc get storagecluster "$OCS_CLUSTER_NAME" -n $OCS_NAMESPACE -o jsonpath='{.status.phase}'
-  ```
-
-### IBM Spectrum Scale webhook issues
-
-* If webhook errors occur (`no endpoints available for service "ibm-spectrum-scale-controller-manager-service"`), check for duplicate or conflicting webhooks.
-* Set `failurePolicy: Ignore` to disable the webhook.
-
-### LocalDisks in use
-
-* If a disk is reported as already in use, set `skipVerify: true` in the `LocalDisk` CR in the `$SCALE_NAMESPACE` namespace.
-
-### Node draining / stuck Node issues
-
-* If a node is stuck during draining, check Machine Config Operator (MCO) logs and either manually scale down or force delete the affected pod replicas to proceed.
-* If MCO shows no issues and the node is cordoned (scheduling disabled), uncordon the node manually.
-
-### Scale Container Native lingering files and kernel modules
-
-* If, prior to running the script, a previous installation of Scale Container Native was not cleanly uninstalled, it may be necessary to reboot the OpenShift nodes to bring the system back to a clean state.
-  * Only reboot one node at a time, and wait for it to come back `Ready` before proceeding to another node.
-* See the [Scale Container Native documentation](https://www.ibm.com/docs/en/scalecontainernative/6.0.0?topic=cleanup) for complete cleanup instructions.
+* [Migration Guide](docs/MIGRATION.md)
+* [Troubleshooting](docs/TROUBLESHOOTING.md)
+* [Known Issues and Manual Workarounds](docs/KNOWN_ISSUES.md)

--- a/CAS/local-data-caching/bin/cleanup-data-cache.sh
+++ b/CAS/local-data-caching/bin/cleanup-data-cache.sh
@@ -10,14 +10,10 @@ source "$ROOT_DIR/lib/constants.sh"
 source "$ROOT_DIR/config/config.env"
 set +a
 
+# shellcheck source=lib/logging.sh
+source "$ROOT_DIR/lib/logging.sh"
 # shellcheck source=modules/df_utils.sh
 source "$ROOT_DIR/modules/df_utils.sh"
-
-LOG_DIR="./logs"
-LOG_FILE="$LOG_DIR/cleanup-data-cache-$(date +'%Y%m%d_%H%M%S').log"
-mkdir -p "$LOG_DIR"
-exec > >(tee -a "$LOG_FILE") 2>&1
-echo "Logging initialized. All output will be saved to $LOG_FILE"
 
 oc project default
 
@@ -37,13 +33,12 @@ echo "Fusion environment: ${ENV}"
 wait_for_delete() {
 	local namespace="$1"
 	shift
-	local resources=("$@")
 
 	local any_exist=true
 	while $any_exist; do
 		any_exist=false
 		local existing_resources=""
-		for resource in "${resources[@]}"; do
+		for resource in "$@"; do
 			local count
 			count=$(oc get "${resource}" -n "${namespace}" --no-headers=true 2>/dev/null | wc -l)
 			if [[ "${count}" -gt 0 ]]; then
@@ -137,7 +132,7 @@ cleanup_cnsa() {
 		echo "Skipping local storage cleanup - filesystem with device volumes was found"
 	else
 		envsubst <templates/daemonset_expose_rbd.yaml | oc delete -f - --ignore-not-found=true
-		envsubst <templates/pvc_local_disks.yaml | oc delete -f - --ignore-not-found=true
+		rbd_pvcs_yaml | oc delete -f - --ignore-not-found=true
 		oc delete project "$LOCAL_STORAGE_PROJECT" --ignore-not-found=true
 	fi
 	oc delete project "$SCALE_NAMESPACE" --ignore-not-found=true --wait=false

--- a/CAS/local-data-caching/bin/customer_cas_cleanup.sh
+++ b/CAS/local-data-caching/bin/customer_cas_cleanup.sh
@@ -1,0 +1,743 @@
+#!/bin/bash
+
+###############################################################################
+# Script Name: customer_cas_cleanup.sh (Enhanced Version)
+# Purpose: Safely uninstall the CAS service from OpenShift with proper ordering
+#
+# IMPROVEMENTS:
+#    - Scale down deployments/statefulsets BEFORE deletion to prevent restarts
+#    - Better parade resource preservation (all resources, not just secrets)
+#    - Proper cleanup ordering to prevent resource recreation
+#    - Better finalizer handling in all cleanup functions
+#    - Prevents valkey reinstallation when namespace is preserved
+#    - Handles stuck PVCs with finalizers consistently
+#    - More granular resource selection to avoid parade deletion
+#
+# FEATURES:
+#    - Deletes CAS Custom Resources (CasInstall)
+#    - Cleans up Kafka resources (topics, users, brokers)
+#    - Uninstalls CAS operators and related ClusterServiceVersions
+#    - Removes namespace-specific ClusterRoleBindings
+#    - Deletes CAS catalog sources and PVCs (optionally preserved)
+#    - Removes FusionServiceInstance (if applicable)
+#    - Deletes associated Persistent Volumes (PVs) in 'Released' state
+#    - Safely deletes or retains the namespace based on options
+#    - Preserves parade resources when requested
+#
+# Usage:
+#  yes y | bash customer_cas_cleanup.sh [-n <namespace>] [--keep-paradedb] [--keep-namespace] [--help]
+#
+###############################################################################
+
+set -euo pipefail
+
+# Defaults
+NAMESPACE="ibm-cas"
+KEEP_PARADEDB=false
+KEEP_NAMESPACE=false
+RETRY_COUNT=5
+RETRY_INTERVAL=10
+MAX_PARALLEL=5
+
+# ANSI color codes
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Logging functions
+log_info() {
+    echo -e "${BLUE}[INFO]${NC} $*"
+}
+
+log_success() {
+    echo -e "${GREEN}[SUCCESS]${NC} $*"
+}
+
+log_warn() {
+    echo -e "${YELLOW}[WARN]${NC} $*"
+}
+
+log_error() {
+    echo -e "${RED}[ERROR]${NC} $*"
+}
+
+# Help
+print_help() {
+    cat << EOF
+Usage: $0 [options]
+
+Options:
+  -n, --namespace <name>       Target namespace (default: ibm-cas)
+  --keep-paradedb              Do NOT delete cluster-parade resources (ALL resources preserved)
+  --keep-namespace             Do NOT delete the namespace after cleanup
+  --help                       Display this help message
+
+Examples:
+  # Delete everything including namespace
+  $0 -n ibm-cas
+
+  # Keep parade resources but delete namespace
+  $0 -n ibm-cas --keep-paradedb
+
+  # Keep namespace and parade resources
+  $0 -n ibm-cas --keep-paradedb --keep-namespace
+
+Notes:
+  - When --keep-paradedb is set, ALL parade resources are preserved (pods, pvcs, secrets, configmaps, services)
+  - When --keep-namespace is set, operators are scaled down to prevent resource recreation
+  - PVCs with finalizers are automatically handled with user confirmation
+
+EOF
+    exit 0
+}
+
+# Run wrapper with error handling
+run_step() {
+    local step_name="$1"; shift
+    echo ""
+    echo "============================================================"
+    log_info "Starting: $step_name"
+    echo "============================================================"
+    echo ""
+
+    if "$@"; then
+        echo ""
+        echo "============================================================"
+        log_success "Completed: $step_name"
+        echo "============================================================"
+    else
+        log_error "Failed: $step_name (continuing to next step)"
+    fi
+    echo ""
+}
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -n|--namespace)
+            NAMESPACE="$2"
+            shift 2
+            ;;
+        --keep-paradedb|--keep-cluster-parade)
+            KEEP_PARADEDB=true
+            shift
+            ;;
+        --keep-namespace)
+            KEEP_NAMESPACE=true
+            shift
+            ;;
+        --help)
+            print_help
+            ;;
+        *)
+            log_error "Unknown argument: $1"
+            print_help
+            ;;
+    esac
+done
+
+echo "============================================================"
+echo "CAS Cleanup Script - Enhanced Customer-Safe Version"
+echo "============================================================"
+log_info "Target Namespace: $NAMESPACE"
+log_info "Preserve Parade Resources: $KEEP_PARADEDB"
+log_info "Preserve Namespace: $KEEP_NAMESPACE"
+echo "============================================================"
+
+# Confirm
+echo ""
+log_warn "This script will perform the following operations:"
+echo "  1. Scale down CAS operators to prevent resource recreation"
+echo "  2. Delete CAS Custom Resources and operators"
+echo "  3. Delete Kafka resources (topics, users, brokers)"
+echo "  4. Delete CAS-specific pods, services, configmaps, secrets"
+echo "  5. Delete PVCs and associated PVs"
+if [[ "$KEEP_PARADEDB" == true ]]; then
+    log_info "  → Parade resources (ALL types) will be PRESERVED"
+fi
+if [[ "$KEEP_NAMESPACE" == true ]]; then
+    log_info "  → Namespace will be PRESERVED (operators scaled down)"
+else
+    log_warn "  → Namespace will be DELETED"
+fi
+echo ""
+read -rp "Are you sure you want to proceed? (y/n): " CONFIRM
+[[ "$CONFIRM" != "y" ]] && log_warn "Aborted by user." && exit 0
+
+# Check if namespace exists
+if ! oc get ns "$NAMESPACE" &>/dev/null; then
+    log_error "Namespace '$NAMESPACE' does not exist."
+    exit 1
+fi
+
+log_success "Namespace '$NAMESPACE' exists. Proceeding with cleanup..."
+
+# List current state
+echo ""
+log_info "Current Pods in namespace '$NAMESPACE':"
+oc get pods -n "$NAMESPACE" 2>/dev/null || log_warn "No pods found or unable to list pods"
+echo ""
+log_info "Current PVCs in namespace '$NAMESPACE':"
+oc get pvc -n "$NAMESPACE" 2>/dev/null || log_warn "No PVCs found or unable to list PVCs"
+echo ""
+
+# Helper: Check if resource is parade-related
+is_parade_resource() {
+    local resource_name="$1"
+    [[ "$resource_name" =~ ^(cluster-parade|parade-) ]] || [[ "$resource_name" =~ -parade$ ]]
+}
+
+# Retry wrapper with finalizer removal
+retry_until_gone() {
+    local resource=$1
+    local namespace=$2
+    local kind=$3
+
+    for i in $(seq 1 "$RETRY_COUNT"); do
+        local exists=false
+
+        if [[ -z "$namespace" ]]; then
+            oc get "$kind" "$resource" &>/dev/null && exists=true
+        else
+            oc get "$kind" "$resource" -n "$namespace" &>/dev/null && exists=true
+        fi
+
+        if [[ "$exists" == false ]]; then
+            log_success "$kind/$resource deleted successfully"
+            return 0
+        fi
+
+        log_info "[$i/$RETRY_COUNT] Waiting for $kind/$resource to terminate..."
+        sleep "$RETRY_INTERVAL"
+    done
+
+    log_error "$kind/$resource did not delete after $RETRY_COUNT retries"
+    read -rp "Remove finalizers and force delete $kind/$resource? [y/N]: " confirm
+
+    if [[ "$confirm" =~ ^[Yy]$ ]]; then
+        log_info "Removing finalizers from $kind/$resource"
+        if [[ -z "$namespace" ]]; then
+            oc patch "$kind" "$resource" --type=json -p='[{"op":"remove","path":"/metadata/finalizers"}]' 2>/dev/null || true
+            oc patch "$kind" "$resource" --type=merge -p '{"metadata":{"finalizers":[]}}' 2>/dev/null || true
+            oc delete "$kind" "$resource" --wait=false --grace-period=0 --force 2>/dev/null || true
+        else
+            oc patch "$kind" "$resource" -n "$namespace" --type=json -p='[{"op":"remove","path":"/metadata/finalizers"}]' 2>/dev/null || true
+            oc patch "$kind" "$resource" -n "$namespace" --type=merge -p '{"metadata":{"finalizers":[]}}' 2>/dev/null || true
+            oc delete "$kind" "$resource" -n "$namespace" --wait=false --grace-period=0 --force 2>/dev/null || true
+        fi
+    else
+        log_warn "Skipping forced deletion of $kind/$resource"
+    fi
+}
+
+# CRITICAL: Scale down operators FIRST to prevent resource recreation
+scale_down_operators() {
+    log_info "Scaling down operators to prevent resource recreation..."
+
+    # Scale down deployments
+    local deployments
+    deployments=$(oc get deployment -n "$NAMESPACE" --no-headers -o custom-columns=":metadata.name" 2>/dev/null || true)
+
+    for deploy in $deployments; do
+        # Skip parade deployments if preservation is enabled
+        if [[ "$KEEP_PARADEDB" == true ]] && is_parade_resource "$deploy"; then
+            log_info "Skipping parade deployment: $deploy"
+            continue
+        fi
+
+        log_info "Scaling down deployment: $deploy"
+        oc scale deployment "$deploy" -n "$NAMESPACE" --replicas=0 --timeout=60s 2>/dev/null || true
+    done
+
+    # Scale down statefulsets (CRITICAL for valkey)
+    local statefulsets
+    statefulsets=$(oc get sts -n "$NAMESPACE" --no-headers -o custom-columns=":metadata.name" 2>/dev/null || true)
+
+    for sts in $statefulsets; do
+        # Skip parade statefulsets if preservation is enabled
+        if [[ "$KEEP_PARADEDB" == true ]] && is_parade_resource "$sts"; then
+            log_info "Skipping parade statefulset: $sts"
+            continue
+        fi
+
+        log_info "Scaling down statefulset: $sts"
+        oc scale sts "$sts" -n "$NAMESPACE" --replicas=0 --timeout=60s 2>/dev/null || true
+    done
+
+    # Wait for pods to terminate
+    log_info "Waiting for pods to terminate after scale-down..."
+    sleep 10
+
+    log_success "Operators and statefulsets scaled down"
+}
+
+# Delete Kafka resources
+delete_kafka_resources() {
+    log_info "Deleting Kafka resources..."
+
+    local RESOURCES=("kafkatopics.kafka.strimzi.io" "kafkauser.kafka.strimzi.io" "kafka.kafka.strimzi.io")
+
+    for kind in "${RESOURCES[@]}"; do
+        local LIST
+        LIST=$(oc get "$kind" -n "$NAMESPACE" -o name 2>/dev/null || true)
+
+        if [[ -z "$LIST" ]]; then
+            log_info "No $kind resources found"
+            continue
+        fi
+
+        for res in $LIST; do
+            local name="${res#*/}"
+            log_info "Deleting $res..."
+
+            # Remove finalizers first
+            oc patch "$kind" "$name" -n "$NAMESPACE" --type=json -p='[{"op":"remove","path":"/metadata/finalizers"}]' 2>/dev/null || true
+            oc delete "$res" -n "$NAMESPACE" --wait=false 2>/dev/null || true
+            retry_until_gone "$name" "$NAMESPACE" "$kind"
+        done
+    done
+
+    log_success "Kafka resources cleanup completed"
+}
+
+# Uninstall CAS operators
+uninstall_operators() {
+    log_info "Uninstalling CAS operators..."
+
+    local SUBS
+    SUBS=$(oc get subscriptions -n "$NAMESPACE" -o name 2>/dev/null || true)
+
+    if [[ -z "$SUBS" ]]; then
+        log_info "No subscriptions found"
+        return 0
+    fi
+
+    for sub in $SUBS; do
+        local name="${sub#*/}"
+        local CSV
+        CSV=$(oc get "$sub" -n "$NAMESPACE" -o jsonpath='{.status.installedCSV}' 2>/dev/null || true)
+
+        log_info "Deleting subscription: $name"
+        oc delete "$sub" -n "$NAMESPACE" --wait=false 2>/dev/null || true
+        retry_until_gone "$name" "$NAMESPACE" "Subscription"
+
+        if [[ -n "$CSV" ]]; then
+            log_info "Deleting CSV: $CSV"
+            oc patch clusterserviceversion "$CSV" -n "$NAMESPACE" --type=json \
+                -p='[{"op":"remove","path":"/metadata/finalizers"}]' 2>/dev/null || true
+            oc delete clusterserviceversion "$CSV" -n "$NAMESPACE" --wait=false 2>/dev/null || true
+            retry_until_gone "$CSV" "$NAMESPACE" "clusterserviceversion"
+        fi
+    done
+
+    log_success "Operators uninstalled"
+}
+
+# Cleanup PVCs with proper parade preservation
+cleanup_pvcs() {
+    log_info "Starting PVC cleanup in namespace: $NAMESPACE"
+
+    local PVC_LIST
+    PVC_LIST=$(oc get pvc -n "$NAMESPACE" --no-headers -o custom-columns=":metadata.name" 2>/dev/null || true)
+
+    if [[ -z "$PVC_LIST" ]]; then
+        log_info "No PVCs found"
+        return 0
+    fi
+
+    local JOBS=0
+
+    for pvc in $PVC_LIST; do
+        # Skip parade PVCs if preservation is enabled
+        if [[ "$KEEP_PARADEDB" == true ]] && is_parade_resource "$pvc"; then
+            log_info "Skipping parade PVC: $pvc"
+            continue
+        fi
+
+        (
+            log_info "Deleting PVC: $pvc"
+
+            # Remove finalizers
+            oc patch pvc "$pvc" -n "$NAMESPACE" --type=json \
+                -p='[{"op":"remove","path":"/metadata/finalizers"}]' 2>/dev/null || true
+
+            oc delete pvc "$pvc" -n "$NAMESPACE" --wait=false 2>/dev/null || true
+            retry_until_gone "$pvc" "$NAMESPACE" "pvc"
+
+            # Handle associated PV
+            local PV
+            PV=$(oc get pv --no-headers -o custom-columns=":metadata.name,:spec.claimRef.name" 2>/dev/null | \
+                 grep "$pvc" | awk '{print $1}' || true)
+
+            if [[ -n "$PV" ]]; then
+                log_info "Processing PV $PV linked to PVC $pvc"
+                local STATUS
+                STATUS=$(oc get pv "$PV" -o jsonpath='{.status.phase}' 2>/dev/null || true)
+                log_info "PV $PV status is $STATUS"
+
+                if [[ "$STATUS" =~ ^(Released|Failed|Terminating)$ ]]; then
+                    log_info "PV $PV is in state $STATUS, removing finalizers"
+                    oc patch pv "$PV" --type=json \
+                        -p='[{"op":"remove","path":"/metadata/finalizers"}]' 2>/dev/null || true
+                fi
+
+                log_info "Deleting PV $PV"
+                oc delete pv "$PV" --wait=false 2>/dev/null || true
+                retry_until_gone "$PV" "" "pv"
+            fi
+        ) &
+
+        JOBS=$((JOBS + 1))
+
+        # Control parallel jobs
+        while [[ $(jobs -rp | wc -l) -ge $MAX_PARALLEL ]]; do
+            sleep 1
+        done
+    done
+
+    wait
+    log_success "PVC and PV cleanup complete"
+}
+
+# Delete FusionServiceInstance
+delete_fusion_service_instances() {
+    log_info "Deleting FusionServiceInstance resources..."
+
+    local fusion_ns instance_name mandatory
+
+    # Discover the namespace
+    fusion_ns=$(oc get spectrumfusion -A --no-headers 2>/dev/null | cut -d" " -f1 | head -n1)
+    [ -z "$fusion_ns" ] && fusion_ns=$(oc get subs -A -o custom-columns=:metadata.namespace,:spec.name 2>/dev/null | \
+                                       grep "isf-operator$" | cut -d" " -f1)
+    [ -z "$fusion_ns" ] && fusion_ns="ibm-spectrum-fusion-ns"
+
+    local instances=(
+        "ibm-cas-service-instance:true"
+        "cas-install-redstack:false"
+    )
+
+    for entry in "${instances[@]}"; do
+        instance_name="${entry%%:*}"
+        mandatory="${entry##*:}"
+
+        if oc get fusionserviceinstance "$instance_name" -n "$fusion_ns" &>/dev/null; then
+            log_info "Deleting FusionServiceInstance '$instance_name' from $fusion_ns"
+
+            # Remove finalizers
+            oc patch fusionserviceinstance "$instance_name" -n "$fusion_ns" --type=json \
+                -p='[{"op":"remove","path":"/metadata/finalizers"}]' 2>/dev/null || true
+
+            oc delete fusionserviceinstance "$instance_name" -n "$fusion_ns" --wait=false 2>/dev/null || true
+            retry_until_gone "$instance_name" "$fusion_ns" "fusionserviceinstance"
+        elif [ "$mandatory" = "true" ]; then
+            log_warn "Mandatory FusionServiceInstance '$instance_name' not found in $fusion_ns"
+        else
+            log_info "Optional FusionServiceInstance '$instance_name' not found, skipping"
+        fi
+    done
+
+    log_success "FusionServiceInstance cleanup completed"
+}
+
+# Delete CAS CatalogSource
+delete_catalog_source() {
+    log_info "Deleting CAS CatalogSource..."
+
+    if oc get catalogsource ibm-isf-cas-operator-catalog -n "$NAMESPACE" &>/dev/null; then
+        oc delete catalogsource ibm-isf-cas-operator-catalog -n "$NAMESPACE" --wait=true 2>/dev/null || true
+        log_success "CatalogSource deleted"
+    else
+        log_info "CatalogSource not found"
+    fi
+}
+
+# Delete CAS-specific CRD instances
+delete_cas_crd_instances() {
+    log_info "Looking for CAS-specific CRDs (excluding Kafka CRDs)..."
+
+    local CAS_CRDS
+    CAS_CRDS=$(oc get crd --no-headers -o custom-columns=":metadata.name" 2>/dev/null | grep -i "cas.isf" || true)
+
+    if [ -z "$CAS_CRDS" ]; then
+        log_info "No CAS CRDs found"
+        return 0
+    fi
+
+    for crd in $CAS_CRDS; do
+        local resource
+        resource=$(echo "$crd" | cut -d '.' -f1)
+
+        log_info "Processing CRD: $crd (Resource: $resource)"
+
+        local instances
+        instances=$(oc get "$resource" -n "$NAMESPACE" --no-headers \
+            -o custom-columns="NAME:.metadata.name" 2>/dev/null || true)
+
+        if [ -z "$instances" ]; then
+            log_info "No instances found for $resource in namespace $NAMESPACE"
+            continue
+        fi
+
+        for name in $instances; do
+            log_info "Deleting $resource/$name in namespace $NAMESPACE"
+
+            # Remove finalizers (both methods for safety)
+            oc patch "$resource" "$name" -n "$NAMESPACE" --type=json \
+                -p='[{"op":"remove","path":"/metadata/finalizers"}]' 2>/dev/null || true
+
+            oc patch "$resource" "$name" -n "$NAMESPACE" --type=merge \
+                -p '{"metadata":{"finalizers":[]}}' 2>/dev/null || true
+
+            # Delete instance
+            oc delete "$resource" "$name" -n "$NAMESPACE" --ignore-not-found=true --wait=false 2>/dev/null
+
+            # Wait until gone
+            retry_until_gone "$name" "$NAMESPACE" "$resource"
+        done
+    done
+
+    log_success "CAS CRD instances cleanup completed"
+}
+
+# Resource cleanup with proper parade preservation
+resource_cleanup() {
+    log_info "Starting resource cleanup in namespace: $NAMESPACE"
+
+    local JOBS=0
+
+    control_parallel() {
+        while [[ $(jobs -rp | wc -l) -ge $MAX_PARALLEL ]]; do
+            sleep 1
+        done
+    }
+
+    # STEP 1: Delete StatefulSets (if not already scaled down)
+    log_info "Deleting StatefulSets..."
+
+    local sts_list
+    sts_list=$(oc get sts -n "$NAMESPACE" --no-headers -o custom-columns=":metadata.name" 2>/dev/null || true)
+
+    if [[ -z "$sts_list" ]]; then
+        log_info "No StatefulSets found"
+    else
+        for sts in $sts_list; do
+            # Skip parade statefulsets
+            if [[ "$KEEP_PARADEDB" == true ]] && is_parade_resource "$sts"; then
+                log_info "Preserving parade StatefulSet: $sts"
+                continue
+            fi
+
+            control_parallel
+            (
+                log_info "Deleting StatefulSet $sts"
+                oc patch sts "$sts" -n "$NAMESPACE" --type=json \
+                    -p='[{"op":"remove","path":"/metadata/finalizers"}]' 2>/dev/null || true
+                oc delete sts "$sts" -n "$NAMESPACE" --wait=false 2>/dev/null || true
+                retry_until_gone "$sts" "$NAMESPACE" "sts"
+            ) &
+        done
+        wait
+    fi
+
+    log_success "StatefulSets deletion completed"
+
+    # STEP 2: Delete Deployments
+    log_info "Deleting Deployments..."
+
+    local deploy_list
+    deploy_list=$(oc get deployment -n "$NAMESPACE" --no-headers -o custom-columns=":metadata.name" 2>/dev/null || true)
+
+    if [[ -n "$deploy_list" ]]; then
+        for deploy in $deploy_list; do
+            # Skip parade deployments
+            if [[ "$KEEP_PARADEDB" == true ]] && is_parade_resource "$deploy"; then
+                log_info "Preserving parade Deployment: $deploy"
+                continue
+            fi
+
+            control_parallel
+            (
+                log_info "Deleting Deployment $deploy"
+                oc delete deployment "$deploy" -n "$NAMESPACE" --wait=false 2>/dev/null || true
+                retry_until_gone "$deploy" "$NAMESPACE" "deployment"
+            ) &
+        done
+        wait
+    fi
+
+    log_success "Deployments deletion completed"
+
+    # STEP 3: Delete remaining Pods
+    log_info "Deleting remaining pods..."
+
+    oc get pods -n "$NAMESPACE" --no-headers 2>/dev/null | \
+        awk '{print $1, $3}' | \
+        while read -r pod status; do
+            # Skip parade pods
+            if [[ "$KEEP_PARADEDB" == true ]] && is_parade_resource "$pod"; then
+                log_info "Preserving parade pod: $pod"
+                continue
+            fi
+
+            if [[ "$status" =~ ^(Running|CrashLoopBackOff|Pending|Failed|Terminating|Error)$ ]]; then
+                control_parallel
+                (
+                    log_info "Deleting pod $pod (status: $status)"
+                    oc delete pod "$pod" -n "$NAMESPACE" \
+                        --grace-period=0 \
+                        --force \
+                        --wait=false 2>/dev/null || true
+                    retry_until_gone "$pod" "$NAMESPACE" "pod"
+                ) &
+            fi
+        done
+
+    wait
+    log_success "Pod cleanup completed"
+
+    # STEP 4: Delete other namespaced resources (with parade preservation)
+    local resources=("service" "route" "job" "cronjob")
+
+    for res in "${resources[@]}"; do
+        log_info "Deleting $res resources..."
+
+        oc get "$res" -n "$NAMESPACE" --no-headers \
+            -o custom-columns=":metadata.name" 2>/dev/null | \
+        while read -r name; do
+            # Skip parade resources
+            if [[ "$KEEP_PARADEDB" == true ]] && is_parade_resource "$name"; then
+                log_info "Preserving parade $res: $name"
+                continue
+            fi
+
+            control_parallel
+            (
+                log_info "Deleting $res/$name"
+                oc delete "$res" "$name" -n "$NAMESPACE" --wait=false 2>/dev/null || true
+                retry_until_gone "$name" "$NAMESPACE" "$res"
+            ) &
+        done
+    done
+
+    wait
+    log_success "Resource cleanup completed"
+}
+
+# Final cleanup with parade preservation
+final_cleanup() {
+    log_info "Starting final cleanup of remaining resources..."
+
+    # Delete secrets (with parade preservation)
+    log_info "Cleaning up secrets..."
+    oc get secrets -n "$NAMESPACE" --no-headers -o custom-columns=":metadata.name" 2>/dev/null | \
+    while read -r secret; do
+        # Skip default service account tokens and parade secrets
+        if [[ "$secret" =~ ^(default-token|builder-token|deployer-token) ]]; then
+            continue
+        fi
+
+        if [[ "$KEEP_PARADEDB" == true ]] && is_parade_resource "$secret"; then
+            log_info "Preserving parade secret: $secret"
+            continue
+        fi
+
+        oc delete secret "$secret" -n "$NAMESPACE" --ignore-not-found=true 2>/dev/null || true
+    done
+
+    # Delete configmaps (with parade preservation)
+    log_info "Cleaning up configmaps..."
+    oc get configmaps -n "$NAMESPACE" --no-headers -o custom-columns=":metadata.name" 2>/dev/null | \
+    while read -r cm; do
+        if [[ "$KEEP_PARADEDB" == true ]] && is_parade_resource "$cm"; then
+            log_info "Preserving parade configmap: $cm"
+            continue
+        fi
+
+        oc delete configmap "$cm" -n "$NAMESPACE" --ignore-not-found=true 2>/dev/null || true
+    done
+
+    # Delete network policies
+    log_info "Cleaning up network policies..."
+    oc delete networkpolicy docling-deny-all-egress -n "$NAMESPACE" --ignore-not-found=true 2>/dev/null || true
+    oc delete networkpolicy docling-allow-local-egress -n "$NAMESPACE" --ignore-not-found=true 2>/dev/null || true
+
+    # Delete rolebindings
+    log_info "Cleaning up rolebindings..."
+    oc delete rolebindings --all -n "$NAMESPACE" --ignore-not-found=true 2>/dev/null || true
+
+    log_success "Final cleanup completed"
+}
+
+# Delete namespace
+delete_namespace() {
+    if [[ "$KEEP_NAMESPACE" == false ]]; then
+        log_info "Deleting Namespace: $NAMESPACE"
+
+        # Remove finalizers from namespace
+        oc patch namespace "$NAMESPACE" --type=json \
+            -p='[{"op":"remove","path":"/metadata/finalizers"}]' 2>/dev/null || true
+
+        oc delete namespace "$NAMESPACE" --wait=false 2>/dev/null || true
+        retry_until_gone "$NAMESPACE" "" "namespace"
+
+        log_success "Namespace deleted"
+    else
+        log_info "Namespace $NAMESPACE preserved (--keep-namespace)"
+
+        if [[ "$KEEP_PARADEDB" == true ]]; then
+            log_info "Checking parade resources in preserved namespace..."
+            local parade_pods
+            parade_pods=$(oc get pods -n "$NAMESPACE" --no-headers 2>/dev/null | grep -E "^(cluster-parade|parade-)" | wc -l)
+            log_info "Parade pods preserved: $parade_pods"
+
+            local parade_pvcs
+            parade_pvcs=$(oc get pvc -n "$NAMESPACE" --no-headers 2>/dev/null | grep -E "^(cluster-parade|parade-)" | wc -l)
+            log_info "Parade PVCs preserved: $parade_pvcs"
+        fi
+    fi
+}
+
+#######################################
+### MAIN EXECUTION FLOW ###
+#######################################
+
+# CRITICAL: Scale down operators FIRST to prevent resource recreation
+run_step "Scale Down Operators and StatefulSets" scale_down_operators
+
+# Delete CAS-specific resources
+run_step "Delete CAS CRD Instances" delete_cas_crd_instances
+run_step "Delete Fusion Service Instances" delete_fusion_service_instances
+run_step "Delete Catalog Source" delete_catalog_source
+run_step "Delete Kafka Resources" delete_kafka_resources
+run_step "Uninstall Operators" uninstall_operators
+
+# Delete workloads and resources
+run_step "Resource Cleanup (Deployments, StatefulSets, Pods)" resource_cleanup
+run_step "Cleanup PVCs and PVs" cleanup_pvcs
+run_step "Final Resource Cleanup (Secrets, ConfigMaps, etc.)" final_cleanup
+
+# Delete namespace (if requested)
+run_step "Delete Namespace" delete_namespace
+
+# Summary
+echo ""
+echo "============================================================"
+log_success "IBM CAS cleanup completed successfully"
+echo "============================================================"
+
+if [[ "$KEEP_PARADEDB" == true ]]; then
+    log_info "Parade resources preserved:"
+    log_info "  - Pods, StatefulSets, Deployments"
+    log_info "  - PVCs and PVs"
+    log_info "  - Secrets and ConfigMaps"
+    log_info "  - Services and Routes"
+fi
+
+if [[ "$KEEP_NAMESPACE" == true ]]; then
+    log_info "Namespace '$NAMESPACE' has been preserved"
+    log_info "All CAS operators have been scaled down to prevent resource recreation"
+fi
+
+echo ""

--- a/CAS/local-data-caching/bin/migrate-data-cache.sh
+++ b/CAS/local-data-caching/bin/migrate-data-cache.sh
@@ -1,0 +1,716 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+
+# Load configuration
+set -a
+# shellcheck source=lib/constants.sh
+source "$ROOT_DIR/lib/constants.sh"
+# shellcheck source=config/config.env
+source "$ROOT_DIR/config/config.env"
+set +a
+
+# Load utilities
+# shellcheck source=lib/logging.sh
+source "$ROOT_DIR/lib/logging.sh"
+# shellcheck source=lib/utils.sh
+source "$ROOT_DIR/lib/utils.sh"
+# shellcheck source=modules/ocp_cluster_utils.sh
+source "$ROOT_DIR/modules/ocp_cluster_utils.sh"
+# shellcheck source=modules/cas_utils.sh
+source "$ROOT_DIR/modules/cas_utils.sh"
+
+# Set defaults for launcher-specific options (core config comes from sourced files)
+JOB_TIMEOUT="${JOB_TIMEOUT:-1800}"
+SKIP_VALIDATION="${SKIP_VALIDATION:-false}"
+DRY_RUN="${DRY_RUN:-false}"
+DRY_RUN_JOB="${DRY_RUN_JOB:-false}"
+DELETE_PREVIOUS_JOBS="${DELETE_PREVIOUS_JOBS:-false}"
+PRESERVE_JOB_RESOURCES="${PRESERVE_JOB_RESOURCES:-true}"
+JOB_NAME="${JOB_NAME:-cas-fs-migration-$(date +%Y%m%d-%H%M%S)}"
+MIGRATION_PHASE="${MIGRATION_PHASE:-}"
+MIGRATION_PVC_NAME="${MIGRATION_PVC_NAME:-${CAS_SERVICE_NAME}-migration-pvc}"
+
+# Migration script tracking (computed at initialization)
+MIGRATION_SCRIPT_FILE="${MIGRATION_SCRIPT_FILE:-${ROOT_DIR}/jobs/migration.sh}"
+MIGRATION_SCRIPT_HASH=$(compute_script_hash "${MIGRATION_SCRIPT_FILE}" 2>/dev/null || echo "")
+MIGRATION_CM_NAME="cas-migration-scripts-${MIGRATION_SCRIPT_HASH}"
+
+cleanup_resources() {
+	local namespace="${CAS_NAMESPACE}"
+
+	logger info "Cleanup: all migration resources"
+
+	if [[ "${PRESERVE_JOB_RESOURCES}" == "true" ]]; then
+		logger info "Preserving resources for debugging"
+		logger info "To delete all migration Jobs: oc delete jobs -n ${namespace} -l app=${MIGRATION_APP_LABEL}"
+		logger info "To cleanup: PRESERVE_JOB_RESOURCES=false ./migrate-data-cache.sh --migration-phase cleanup"
+		return 0
+	fi
+
+	# Delete all Jobs with MIGRATION_APP_LABEL
+	logger info "Deleting all migration Jobs..."
+	oc delete jobs -n "${namespace}" \
+		-l "app=${MIGRATION_APP_LABEL}" \
+		--ignore-not-found=true
+
+	# Delete ConfigMaps created by this script
+	logger info "Deleting migration ConfigMaps..."
+	oc delete configmap -n "${namespace}" \
+		-l "app=${MIGRATION_APP_LABEL}" \
+		--ignore-not-found=true 2>/dev/null || true
+
+	# Delete NetworkPolicy
+	logger info "Deleting migration NetworkPolicy..."
+	oc delete networkpolicy -n "${namespace}" \
+		-l "app=${MIGRATION_APP_LABEL}" \
+		--ignore-not-found=true 2>/dev/null || true
+
+	# Delete migration PVC
+	logger info "Deleting migration PVC: ${MIGRATION_PVC_NAME}"
+	oc delete pvc "${MIGRATION_PVC_NAME}" -n "${namespace}" \
+		--ignore-not-found=true
+
+	# Delete RBAC resources (SA, Role, RoleBinding, ClusterRole, ClusterRoleBinding)
+	logger info "Deleting migration RBAC resources..."
+	export CAS_NAMESPACE="${namespace}"
+	export MIGRATION_APP_LABEL
+	envsubst < "${ROOT_DIR}/templates/migration/cas_migration_rbac.yaml" \
+		| oc delete -f - --ignore-not-found=true 2>/dev/null || true
+
+	logger success "Cleanup complete"
+	return 0
+}
+
+# Trap handler for cleanup on exit
+cleanup_on_exit() {
+	local exit_code=$?
+	if [[ -n "${JOB_NAME:-}" ]] && [[ -n "${CAS_NAMESPACE:-}" ]]; then
+		# Preserve resources by default for debugging
+		cleanup_resources "${JOB_NAME}" "${CAS_NAMESPACE}" "true"
+	fi
+	exit "${exit_code}"
+}
+
+trap cleanup_on_exit EXIT INT TERM
+
+show_help() {
+	cat << EOF
+Usage: migrate-data-cache.sh --migration-phase <phase> [OPTIONS]
+
+Orchestrate CAS data cache migration by launching Kubernetes Jobs.
+
+REQUIRED:
+  --migration-phase <phase>    Migration phase: pre, post, full, or cleanup
+
+OPTIONS:
+  --filesystem-name <name>     Filesystem name (default: ${FILESYSTEM_NAME})
+  --cas-namespace <ns>         CAS namespace (default: ${CAS_NAMESPACE})
+  --scale-namespace <ns>       Scale namespace (default: ${SCALE_NAMESPACE})
+  --migration-pvc-name <name>  Migration PVC name (default: ${CAS_SERVICE_NAME}-migration-pvc)
+  --job-name <name>            Custom job name (default: auto-generated)
+  --timeout <seconds>          Job timeout (default: ${JOB_TIMEOUT})
+  --skip-validation            Skip prerequisite validation (dangerous!)
+  --dry-run                    Echo create/apply commands instead of executing
+  --dry-run-job                Job echoes commands instead of executing (for testing)
+  --help, -h                   Show this help
+
+ENVIRONMENT VARIABLES:
+  DELETE_PREVIOUS_JOBS=true    Delete existing Jobs for the phase before running (allows re-run after failure)
+  PRESERVE_JOB_RESOURCES=false Delete all migration resources on exit (default: true — preserve for debugging)
+
+PHASES:
+  pre      Back up DataSources and record migration state before upgrades
+  post     Restore DataSources from backup after upgrades; removes all migration resources on success
+  full     Execute pre and post phases in sequence; removes all migration resources on success
+  cleanup  Delete all migration resources (Jobs, ConfigMaps, NetworkPolicy, PVC, RBAC) without running a Job
+
+EXAMPLES:
+  # Pre-migration backup
+  ./migrate-data-cache.sh --migration-phase pre
+
+  # Post-migration restore with custom timeout
+  ./migrate-data-cache.sh --migration-phase post --timeout 3600
+
+  # Re-run after a failed pre (delete the previous failed Job first)
+  DELETE_PREVIOUS_JOBS=true ./migrate-data-cache.sh --migration-phase pre
+
+  # Tear down all migration resources after a confirmed complete migration
+  PRESERVE_JOB_RESOURCES=false ./migrate-data-cache.sh --migration-phase cleanup
+
+PREREQUISITES:
+  - OpenShift cluster connection (oc login)
+  - Cluster admin privileges
+  - Fusion 2.12.x, CAS 1.1.4
+  - Script-deployed cache-fs
+EOF
+}
+
+require_argument_value() {
+	local option="$1"
+	local value="${2:-}"
+
+	if [[ -z "$value" || "$value" == --* ]]; then
+		logger error "Option ${option} requires a value"
+		exit 1
+	fi
+}
+
+parse_arguments() {
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--migration-phase)
+			require_argument_value "$1" "${2:-}"
+			MIGRATION_PHASE="$2"
+			shift 2
+			;;
+		--filesystem-name)
+			require_argument_value "$1" "${2:-}"
+			FILESYSTEM_NAME="$2"
+			shift 2
+			;;
+		--cas-namespace)
+			require_argument_value "$1" "${2:-}"
+			CAS_NAMESPACE="$2"
+			shift 2
+			;;
+		--scale-namespace)
+			require_argument_value "$1" "${2:-}"
+			SCALE_NAMESPACE="$2"
+			shift 2
+			;;
+		--migration-pvc-name)
+			require_argument_value "$1" "${2:-}"
+			MIGRATION_PVC_NAME="$2"
+			shift 2
+			;;
+		--job-name)
+			require_argument_value "$1" "${2:-}"
+			JOB_NAME="$2"
+			shift 2
+			;;
+		--timeout)
+			require_argument_value "$1" "${2:-}"
+			JOB_TIMEOUT="$2"
+			shift 2
+			;;
+		--skip-validation)
+			SKIP_VALIDATION=true
+			shift
+			;;
+		--dry-run)
+			DRY_RUN=true
+			shift
+			;;
+		--dry-run-job)
+			DRY_RUN_JOB=true
+			shift
+			;;
+		--help | -h)
+			show_help
+			exit 0
+			;;
+		*)
+			logger error "Unknown option: $1"
+			echo "Use --help to see usage."
+			exit 1
+			;;
+		esac
+	done
+
+	if [[ -z "${MIGRATION_PHASE}" ]]; then
+		logger error "--migration-phase is required"
+		show_help
+		exit 1
+	fi
+
+	if [[ ! "${MIGRATION_PHASE}" =~ ^(pre|post|full|cleanup)$ ]]; then
+		logger error "Invalid phase: ${MIGRATION_PHASE}"
+		logger error "Must be: pre, post, full, or cleanup"
+		exit 1
+	fi
+}
+
+delete_previous_migration_jobs() {
+	local namespace="${1}"
+	local phase="${2}"
+	local jobs
+
+	jobs=$(oc get jobs -n "${namespace}" \
+		-l "app=${MIGRATION_APP_LABEL},migration-phase=${phase}" \
+		-o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' 2>/dev/null || true)
+
+	if [[ -z "${jobs}" ]]; then
+		logger info "No previous ${phase}-migration Jobs found to delete"
+		return 0
+	fi
+
+	logger warn "Deleting previous ${phase}-migration Jobs"
+	while IFS= read -r job_name; do
+		[[ -z "${job_name}" ]] && continue
+		logger info "Deleting Job: ${job_name}"
+		oc delete job "${job_name}" -n "${namespace}" --ignore-not-found=true >/dev/null
+	done <<< "${jobs}"
+
+	logger success "Previous ${phase}-migration Jobs deleted"
+	return 0
+}
+
+run_validations() {
+	logger info "Starting CLI launcher prerequisite validation..."
+	
+	# Skip if requested (dangerous!)
+	if [[ "${SKIP_VALIDATION}" == "true" ]]; then
+		logger warn "Skipping validation (--skip-validation flag)"
+		return 0
+	fi
+
+	# Run CLI launcher validations in sequence
+	check_ocp_connection || exit 1
+	check_cluster_admin || exit 1
+	validate_cas_namespace "${CAS_NAMESPACE}" || exit 1
+
+	if [[ "${DELETE_PREVIOUS_JOBS}" == "true" ]]; then
+		delete_previous_migration_jobs "${CAS_NAMESPACE}" "${MIGRATION_PHASE}" || exit 1
+	fi
+
+	check_migration_state "${CAS_NAMESPACE}" "${MIGRATION_PHASE}" || exit 1
+	
+	logger success "All CLI launcher validations passed"
+	logger info "Additional validations (versions, cache-fs, Scale namespace) will be performed by the migration script"
+	return 0
+}
+
+ensure_migration_pvc() {
+	local pvc_name="${1}"
+	local namespace="${2}"
+	
+	logger info "Checking for migration PVC: ${pvc_name}"
+	
+	# Check if PVC already exists
+	if oc get pvc "${pvc_name}" -n "${namespace}" &>/dev/null; then
+		logger info "PVC exists: ${pvc_name}"
+		return 0
+	fi
+	
+	logger info "Creating migration PVC: ${pvc_name}"
+	
+	if [[ "${DRY_RUN}" == "true" ]]; then
+		logger info "[DRY-RUN] Would create PVC: ${pvc_name}"
+		logger info "[DRY-RUN]   StorageClass: ocs-storagecluster-cephfs"
+		logger info "[DRY-RUN]   Size: 1Gi"
+		return 0
+	fi
+
+	# Create PVC
+	if ! cat <<EOF | oc apply -f -
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: ${pvc_name}
+  namespace: ${namespace}
+  labels:
+    app: cas-data-cache-migration
+spec:
+  accessModes:
+  - ReadWriteMany
+  resources:
+    requests:
+      storage: 1Gi
+  storageClassName: ocs-storagecluster-cephfs
+EOF
+	then
+		logger error "Failed to create PVC: ${pvc_name}"
+		return 1
+	fi
+	
+	logger success "PVC created: ${pvc_name}"
+	logger info "  StorageClass: ocs-storagecluster-cephfs"
+	logger info "  Size: 1Gi"
+	
+	# Wait for PVC to be bound
+	logger info "Waiting for PVC to be bound..."
+	local timeout=60
+	local elapsed=0
+	while [[ ${elapsed} -lt ${timeout} ]]; do
+		local status
+		status=$(oc get pvc "${pvc_name}" -n "${namespace}" -o jsonpath='{.status.phase}' 2>/dev/null || echo "")
+		
+		if [[ "${status}" == "Bound" ]]; then
+			logger success "PVC bound successfully"
+			return 0
+		fi
+		
+		sleep 2
+		elapsed=$((elapsed + 2))
+	done
+	
+	logger error "PVC did not bind within ${timeout} seconds"
+	return 1
+}
+
+reconcile_configmap() {
+	local template_file="${1}"
+	local namespace="${2}"
+	
+	# Validate migration script exists
+	if [[ ! -f "${MIGRATION_SCRIPT_FILE}" ]]; then
+		logger error "Migration script not found: ${MIGRATION_SCRIPT_FILE}"
+		return 1
+	fi
+	
+	# Validate hash was computed
+	if [[ -z "${MIGRATION_SCRIPT_HASH}" ]]; then
+		logger error "Failed to compute migration script hash"
+		return 1
+	fi
+	
+	# Check if ConfigMap already exists
+	if oc get configmap "${MIGRATION_CM_NAME}" -n "${namespace}" &>/dev/null; then
+		logger info "ConfigMap exists: ${MIGRATION_CM_NAME}"
+		logger info "Reusing (no changes detected)"
+		return 0
+	fi
+	
+	# Create new ConfigMap
+	logger info "Creating ConfigMap: ${MIGRATION_CM_NAME}"
+	
+	# Read and indent the migration script for YAML
+	local migration_script
+	migration_script=$(sed 's/^/    /' "${MIGRATION_SCRIPT_FILE}")
+	
+	# Export variables for envsubst
+	export MIGRATION_CM_NAME
+	export MIGRATION_SCRIPT="${migration_script}"
+	
+	if [[ "${DRY_RUN}" == "true" ]]; then
+		# shellcheck disable=SC2016
+		logger info '[DRY-RUN] envsubst < ${template_file} | oc apply -f -'
+		logger info "[DRY-RUN] ConfigMap would be created: ${MIGRATION_CM_NAME}"
+	else
+		if ! envsubst < "${template_file}" | oc apply -f -; then
+			logger error "Failed to create ConfigMap"
+			return 1
+		fi
+		logger success "ConfigMap created: ${MIGRATION_CM_NAME}"
+	fi
+	
+	return 0
+}
+
+generate_and_apply_job() {
+	local job_name="${1}"
+	local migration_phase="${2}"
+	local configmap_name="${3}"
+	local timestamp="${4}"
+	
+	logger info "Creating Job: ${job_name}"
+	
+	# Export variables for envsubst
+	export JOB_NAME="${job_name}"
+	export MIGRATION_PHASE="${migration_phase}"
+	export MIGRATION_CM_NAME="${configmap_name}"
+	export MIGRATION_PVC_NAME="${MIGRATION_PVC_NAME}"
+	export FILESYSTEM_NAME="${FILESYSTEM_NAME}"
+	export CAS_NAMESPACE="${CAS_NAMESPACE}"
+	export SCALE_NAMESPACE="${SCALE_NAMESPACE}"
+	export MIGRATION_TIMESTAMP="${timestamp}"
+	export DRY_RUN_JOB="${DRY_RUN_JOB}"
+	
+	# Generate and apply
+	if [[ "${DRY_RUN}" == "true" ]]; then
+		# shellcheck disable=SC2016
+		logger info '[DRY-RUN] envsubst < ${ROOT_DIR}/templates/migration/cas_migration_job.yaml | oc apply -f -'
+		logger info "[DRY-RUN] Job would be created: ${job_name}"
+		logger info "[DRY-RUN]   Phase: ${migration_phase}"
+		logger info "[DRY-RUN]   ConfigMap: ${configmap_name}"
+	else
+		if ! envsubst < "${ROOT_DIR}/templates/migration/cas_migration_job.yaml" | oc apply -f -; then
+			logger error "Failed to create Job"
+			envsubst < "${ROOT_DIR}/templates/migration/cas_migration_job.yaml"
+			return 1
+		fi
+		logger success "Job created: ${job_name}"
+		logger info "  Phase: ${migration_phase}"
+		logger info "  ConfigMap: ${configmap_name}"
+	fi
+	return 0
+}
+
+ensure_migration_networkpolicy() {
+	local namespace="${1}"
+	
+	logger info "Ensuring migration NetworkPolicy exists..."
+	
+	# Check if NetworkPolicy already exists
+	if oc get networkpolicy cas-migration-network-policy -n "${namespace}" &>/dev/null; then
+		logger info "NetworkPolicy exists: cas-migration-network-policy"
+		return 0
+	fi
+	
+	logger info "Creating migration NetworkPolicy..."
+	
+	if [[ "${DRY_RUN}" == "true" ]]; then
+		# shellcheck disable=SC2016
+		logger info '[DRY-RUN] envsubst < ${ROOT_DIR}/templates/migration/cas_migration_networkpolicy.yaml | oc apply -f -'
+		logger info "[DRY-RUN] NetworkPolicy would be created: cas-migration-network-policy"
+		return 0
+	fi
+	
+	# Export variables for envsubst
+	export CAS_NAMESPACE="${namespace}"
+	export MIGRATION_APP_LABEL
+	
+	if ! envsubst < "${ROOT_DIR}/templates/migration/cas_migration_networkpolicy.yaml" | oc apply -f -; then
+		logger error "Failed to create NetworkPolicy"
+		return 1
+	fi
+	
+	logger success "NetworkPolicy created: cas-migration-network-policy"
+	return 0
+}
+
+ensure_migration_rbac() {
+	local namespace="${1}"
+
+	logger info "Ensuring migration RBAC resources exist..."
+
+	if [[ "${DRY_RUN}" == "true" ]]; then
+		# shellcheck disable=SC2016
+		logger info '[DRY-RUN] envsubst < ${ROOT_DIR}/templates/migration/cas_migration_rbac.yaml | oc apply -f -'
+		logger info "[DRY-RUN] RBAC resources would be created: cas-migration-sa, cas-migration-anyuid-scc-use, cas-migration-role"
+		return 0
+	fi
+
+	export CAS_NAMESPACE="${namespace}"
+	export MIGRATION_APP_LABEL
+
+	if ! envsubst < "${ROOT_DIR}/templates/migration/cas_migration_rbac.yaml" | oc apply -f -; then
+		logger error "Failed to create migration RBAC resources"
+		return 1
+	fi
+
+	logger success "Migration RBAC resources applied"
+	return 0
+}
+
+set_cas_csv_olm_managed() {
+	local value="${1}"   # "true" or "false"
+	local namespace="${2}"
+
+	local csv_name
+	csv_name=$(oc get csv -n "${namespace}" --no-headers \
+		-o custom-columns=NAME:.metadata.name 2>/dev/null \
+		| grep ibm-isf-cas-operator | head -n1)
+
+	if [[ -z "${csv_name}" ]]; then
+		logger warn "CAS CSV not found in namespace '${namespace}' — skipping olm.managed label"
+		return 0
+	fi
+
+	logger info "Setting CSV '${csv_name}' olm.managed=${value}"
+	oc label csv "${csv_name}" -n "${namespace}" "olm.managed=${value}" --overwrite || {
+		logger warn "Failed to set olm.managed=${value} on CSV '${csv_name}' — continuing"
+	}
+}
+
+delete_cas_webhooks() {
+	local svc="ibm-isf-cas-operator-controller-manager-service"
+
+	logger info "Removing webhooks referencing '${svc}'..."
+
+	local mwc_names
+	mwc_names=$(oc get mutatingwebhookconfigurations -o json 2>/dev/null \
+		| jq -r --arg svc "${svc}" \
+		  '.items[] | select(.webhooks[]?.clientConfig.service.name == $svc) | .metadata.name')
+
+	local vwc_names
+	vwc_names=$(oc get validatingwebhookconfigurations -o json 2>/dev/null \
+		| jq -r --arg svc "${svc}" \
+		  '.items[] | select(.webhooks[]?.clientConfig.service.name == $svc) | .metadata.name')
+
+	if [[ -z "${mwc_names}" && -z "${vwc_names}" ]]; then
+		logger info "No webhooks referencing '${svc}' found"
+		return 0
+	fi
+
+	echo "${mwc_names}" | grep -v '^$' | while read -r name; do
+		logger info "  Deleting MutatingWebhookConfiguration: ${name}"
+		oc delete mutatingwebhookconfiguration "${name}" --ignore-not-found || true
+	done
+
+	echo "${vwc_names}" | grep -v '^$' | while read -r name; do
+		logger info "  Deleting ValidatingWebhookConfiguration: ${name}"
+		oc delete validatingwebhookconfiguration "${name}" --ignore-not-found || true
+	done
+
+	logger success "CAS webhooks removed"
+}
+
+generate_and_apply_resources() {
+	local job_name="${1}"
+	local migration_phase="${2}"
+	local timestamp
+	timestamp=$(date +%Y%m%d-%H%M%S)
+	
+	logger info "Generating migration resources..."
+
+	# Pre-migration only: prevent OLM from restarting the operator while it is
+	# intentionally scaled to 0, and clear any stale webhooks that would block
+	# API writes against CAS CRs when the operator has no endpoints.
+	if [[ "${migration_phase}" == "pre" || "${migration_phase}" == "full" ]]; then
+		set_cas_csv_olm_managed "false" "${CAS_NAMESPACE}"
+		delete_cas_webhooks
+	fi
+
+	# Step 1: Ensure RBAC resources exist (SA + SCC binding + Role + RoleBinding)
+	ensure_migration_rbac "${CAS_NAMESPACE}" || return 1
+
+	# Step 2: Ensure PVC exists
+	ensure_migration_pvc "${MIGRATION_PVC_NAME}" "${CAS_NAMESPACE}" || return 1
+	
+	# Step 3: Ensure NetworkPolicy exists
+	ensure_migration_networkpolicy "${CAS_NAMESPACE}" || return 1
+	
+	# Step 4: ConfigMap (updates MIGRATION_CM_NAME global)
+	reconcile_configmap \
+		"${ROOT_DIR}/templates/migration/cas_migration_configmap.yaml" \
+		"${CAS_NAMESPACE}" || return 1
+
+	# Step 5: Job
+	generate_and_apply_job \
+		"${job_name}" \
+		"${migration_phase}" \
+		"${MIGRATION_CM_NAME}" \
+		"${timestamp}" || return 1
+
+	logger success "Resources created"
+	logger info "  ServiceAccount: cas-migration-sa"
+	logger info "  PVC: ${MIGRATION_PVC_NAME}"
+	logger info "  NetworkPolicy: cas-migration-network-policy"
+	logger info "  ConfigMap: ${MIGRATION_CM_NAME}"
+	logger info "  Job: ${job_name}"
+	return 0
+}
+
+report_job_diagnostics() {
+	local job_name="${1}"
+	local namespace="${2}"
+
+	logger info "Job diagnostics for: ${job_name}"
+
+	local pod_name
+	pod_name=$(oc get pods -n "${namespace}" \
+		-l "job-name=${job_name}" \
+		-o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo "")
+
+	logger info "--- Job Status ---"
+	oc get job "${job_name}" -n "${namespace}" -o wide 2>&1 || true
+
+	if [[ -n "${pod_name}" ]]; then
+		logger info "--- Pod Status ---"
+		oc get pod "${pod_name}" -n "${namespace}" -o wide 2>&1 || true
+
+		logger info "--- Pod Describe ---"
+		oc describe pod "${pod_name}" -n "${namespace}" 2>&1 || true
+
+		logger info "--- Related Events ---"
+		oc get events -n "${namespace}" \
+			--field-selector "involvedObject.name=${pod_name}" \
+			--sort-by=.lastTimestamp 2>&1 || true
+
+		local pod_phase
+		pod_phase=$(oc get pod "${pod_name}" -n "${namespace}" -o jsonpath='{.status.phase}' 2>/dev/null || echo "")
+
+		if [[ "${pod_phase}" == "Failed" ]]; then
+			logger info "--- Pod Logs ---"
+			oc logs "pod/${pod_name}" -n "${namespace}" 2>&1 || true
+		fi
+	else
+		logger warn "No pod found for job diagnostics"
+	fi
+
+	logger info "--- Suggested Commands ---"
+	logger info "oc describe job ${job_name} -n ${namespace}"
+	logger info "oc get pods -n ${namespace} -l job-name=${job_name} -o wide"
+	if [[ -n "${pod_name}" ]]; then
+		logger info "oc describe pod ${pod_name} -n ${namespace}"
+		logger info "oc get events -n ${namespace} --field-selector involvedObject.name=${pod_name} --sort-by=.lastTimestamp"
+		logger info "oc logs pod/${pod_name} -n ${namespace}"
+	fi
+
+	return 0
+}
+
+report_migration_status() {
+	local job_name="${1}"
+	local namespace="${2}"
+	local exit_code="${3}"
+
+	logger info "==================================="
+	logger info "Migration Status Report"
+	logger info "==================================="
+	logger info "Job: ${job_name}"
+	logger info "Namespace: ${namespace}"
+
+	if [[ ${exit_code} -eq 0 ]]; then
+		logger success "Migration completed successfully"
+	else
+		logger error "Migration failed (exit code: ${exit_code})"
+		logger error "Check logs: oc logs job/${job_name} -n ${namespace}"
+		report_job_diagnostics "${job_name}" "${namespace}"
+	fi
+
+	logger info "==================================="
+	logger info ""
+	logger info "NOTICE: Migration PVC '${MIGRATION_PVC_NAME}' was created in namespace '${namespace}'"
+	logger info "        This PVC can be deleted after migration completes:"
+	logger info "        oc delete pvc ${MIGRATION_PVC_NAME} -n ${namespace}"
+	
+	return "${exit_code}"
+}
+
+
+main() {
+	parse_arguments "$@"
+
+	run_validations
+
+	generate_and_apply_resources "${JOB_NAME}" "${MIGRATION_PHASE}" || exit 1
+
+	if [[ "${DRY_RUN}" == "true" ]]; then
+		logger success "[DRY-RUN] Migration Job '${JOB_NAME}' would be created in namespace '${CAS_NAMESPACE}'"
+		logger info "[DRY-RUN] To execute for real, run without --dry-run flag"
+		return 0
+	fi
+
+	logger success "Migration Job '${JOB_NAME}' created in namespace '${CAS_NAMESPACE}'"
+
+	local job_exit_code=0
+	if ! wait_for_job_pod_ready "${JOB_NAME}" "${CAS_NAMESPACE}" 60; then
+		job_exit_code=1
+	else
+		stream_job_logs "${JOB_NAME}" "${CAS_NAMESPACE}" &
+		local log_pid=$!
+
+		if ! wait_for_job_completion "${JOB_NAME}" "${CAS_NAMESPACE}" "${JOB_TIMEOUT}"; then
+			job_exit_code=1
+		fi
+
+		# Wait for log streaming to finish
+		wait "${log_pid}" 2>/dev/null || true
+	fi
+
+	# Post-migration success: restore OLM management of the CAS operator
+	if [[ ${job_exit_code} -eq 0 && ( "${MIGRATION_PHASE}" == "post" || "${MIGRATION_PHASE}" == "full" ) ]]; then
+		set_cas_csv_olm_managed "true" "${CAS_NAMESPACE}"
+	fi
+
+	report_migration_status "${JOB_NAME}" "${CAS_NAMESPACE}" "${job_exit_code}"
+
+	return "${job_exit_code}"
+}
+
+main "$@"

--- a/CAS/local-data-caching/bin/migration-prerequisites.sh
+++ b/CAS/local-data-caching/bin/migration-prerequisites.sh
@@ -1,0 +1,575 @@
+#!/usr/bin/env bash
+# start_Copyright_Notice
+# Licensed Materials - Property of IBM
+
+# IBM Spectrum Fusion 5900-AOY
+# (C) Copyright IBM Corp. 2022 All Rights Reserved.
+
+# US Government Users Restricted Rights - Use, duplication or
+# disclosure restricted by GSA ADP Schedule Contract with
+# IBM Corp.
+# end_Copyright_Notice
+
+#========================================
+# Migration Prerequisites Validation Script
+#========================================
+# Purpose: Validate environment meets all prerequisites before migration
+#
+# This script runs as the first step of the migration Job to ensure:
+#   1. Fusion is installed at a supported version
+#   2. Data Foundation is installed at a supported version
+#   3. CAS is installed at a supported version
+#   4. Script-deployed local cache filesystem exists
+#   5. S3 datasource(s) using cache-fs exist
+#   6. Store validation state for idempotent execution
+#========================================
+
+set -euo pipefail
+
+# Get the directory where this script is located
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# Source required libraries
+# shellcheck source=lib/constants.sh
+source "${PROJECT_ROOT}/lib/constants.sh"
+# shellcheck source=lib/logging.sh
+source "${PROJECT_ROOT}/lib/logging.sh"
+# shellcheck source=lib/utils.sh
+source "${PROJECT_ROOT}/lib/utils.sh"
+# shellcheck source=config/config.env
+source "${PROJECT_ROOT}/config/config.env"
+# shellcheck source=modules/ocp_cluster_utils.sh
+source "${PROJECT_ROOT}/modules/ocp_cluster_utils.sh"
+# shellcheck source=modules/fusion_utils.sh
+source "${PROJECT_ROOT}/modules/fusion_utils.sh"
+# shellcheck source=modules/df_utils.sh
+source "${PROJECT_ROOT}/modules/df_utils.sh"
+# shellcheck source=modules/scale_utils.sh
+source "${PROJECT_ROOT}/modules/scale_utils.sh"
+# shellcheck source=modules/cas_utils.sh
+source "${PROJECT_ROOT}/modules/cas_utils.sh"
+# shellcheck source=modules/olm_utils.sh
+source "${PROJECT_ROOT}/modules/olm_utils.sh"
+
+#========================================
+# Version Comparison Utilities
+#========================================
+
+#----------------------------------------
+# Function: Compare semantic versions
+# Returns: 0 if version1 >= version2, 1 otherwise
+#----------------------------------------
+version_compare() {
+    local version1="$1"
+    local version2="$2"
+    
+    # Remove 'v' prefix if present
+    version1="${version1#v}"
+    version2="${version2#v}"
+    
+    # Split versions into arrays
+    IFS='.' read -ra ver1 <<< "${version1}"
+    IFS='.' read -ra ver2 <<< "${version2}"
+    
+    # Compare each component
+    for i in {0..2}; do
+        local v1="${ver1[$i]:-0}"
+        local v2="${ver2[$i]:-0}"
+        
+        # Remove non-numeric suffixes (e.g., "1.2.3-beta" -> "1.2.3")
+        v1="${v1%%[^0-9]*}"
+        v2="${v2%%[^0-9]*}"
+        
+        if (( v1 > v2 )); then
+            return 0
+        elif (( v1 < v2 )); then
+            return 1
+        fi
+    done
+    
+    return 0  # Versions are equal
+}
+
+#========================================
+# Validation Functions
+#========================================
+
+#----------------------------------------
+# Function: Validate Fusion installation and version
+#----------------------------------------
+validate_fusion() {
+    logger info "Validating IBM Spectrum Fusion installation..."
+    
+    local env_type
+    env_type=$(get_environment_type)
+    echo "FUSION_ENVIRONMENT_TYPE: ${env_type}"
+    
+    local fusion_ns
+    if [[ "${env_type}" == "${HCI_ENVIRONMENT}" ]]; then
+        fusion_ns="${HCI_FUSION_NAMESPACE}"
+    else
+        fusion_ns="${FUSION_NAMESPACE}"
+    fi
+    echo "FUSION_NAMESPACE: ${fusion_ns}"
+
+    # Check if Fusion operator is installed
+    if ! oc get csv -n "${fusion_ns}" 2>/dev/null | grep "${FUSION_PACKAGE_NAME}"; then
+        logger error "Fusion operator not found in namespace ${fusion_ns}"
+        echo "FUSION_INSTALLED: false"
+        FUSION_VERSION_FOUND="N/A"
+        return 1
+    fi
+    
+    # Get Fusion version
+    FUSION_VERSION_FOUND=$(oc get csv -n "${fusion_ns}" -o jsonpath='{.items[?(@.spec.displayName=="IBM Storage Fusion")].spec.version}' 2>/dev/null | head -n1)
+    
+    if [[ -z "${FUSION_VERSION_FOUND}" ]]; then
+        logger error "Unable to determine Fusion version"
+        echo "FUSION_INSTALLED: false"
+        FUSION_VERSION_FOUND="Unknown"
+        return 1
+    fi
+    
+    echo "FUSION_VERSION: ${FUSION_VERSION_FOUND}"
+    logger info "Detected Fusion version: ${FUSION_VERSION_FOUND}"
+    
+    # Validate version meets minimum requirement
+    if ! version_compare "${FUSION_VERSION_FOUND}" "${FUSION_VERSION}"; then
+        logger error "Fusion version ${FUSION_VERSION_FOUND} is below minimum required version ${FUSION_VERSION}"
+        echo "FUSION_VERSION_VALID: false"
+        return 1
+    fi
+    
+    echo "FUSION_INSTALLED: true"
+    echo "FUSION_VERSION_VALID: true"
+    logger success "Fusion validation passed: version ${FUSION_VERSION_FOUND} >= ${FUSION_VERSION}"
+    
+    return 0
+}
+
+#----------------------------------------
+# Function: Validate Data Foundation installation and version
+#----------------------------------------
+validate_data_foundation() {
+    logger info "Validating OpenShift Data Foundation installation..."
+    
+    logger info "${OCS_NAMESPACE}"
+    # Check if ODF namespace exists
+    if ! oc get namespace "${OCS_NAMESPACE}" &>/dev/null; then
+        logger error "ODF namespace ${OCS_NAMESPACE} not found"
+        echo "DF_INSTALLED: false"
+        DF_VERSION_FOUND="N/A"
+        DF_STATUS_FOUND="N/A"
+        return 1
+    fi
+    
+    # Check if StorageCluster exists
+    if ! oc get "${STORAGE_CLUSTER}" "${OCS_CLUSTER_NAME}" -n "${OCS_NAMESPACE}" &>/dev/null; then
+        logger error "StorageCluster ${OCS_CLUSTER_NAME} not found in namespace ${OCS_NAMESPACE}"
+        echo "DF_INSTALLED: false"
+        DF_VERSION_FOUND="N/A"
+        DF_STATUS_FOUND="N/A"
+        return 1
+    fi
+    
+    # Check StorageCluster status
+    local df_status
+    df_status=$(oc get "${STORAGE_CLUSTER}" "${OCS_CLUSTER_NAME}" -n "${OCS_NAMESPACE}" -o jsonpath='{.status.phase}' 2>/dev/null)
+    DF_STATUS_FOUND="${df_status}"
+    
+    if [[ "${df_status}" != "Ready" ]]; then
+        logger error "StorageCluster status is '${df_status}', expected 'Ready'"
+        echo "DF_STATUS: ${df_status}"
+        echo "DF_READY: false"
+        return 1
+    fi
+    
+    # Get ODF version from CSV
+    local df_version
+    df_version=$(oc get csv -n "${OCS_NAMESPACE}" -o json | jq -r '.items[] | select(.spec.displayName | contains("Data Foundation")) | .spec.version' | head -n1)
+    
+    if [[ -z "${df_version}" ]]; then
+        # Try alternative display name
+        df_version=$(oc get csv -n "${OCS_NAMESPACE}" -o jsonpath='{.items[?(@.spec.displayName=="OpenShift Container Storage")].spec.version}' 2>/dev/null | head -n1)
+    fi
+    
+    if [[ -z "${df_version}" ]]; then
+        logger warn "Unable to determine Data Foundation version, proceeding with caution"
+        echo "DF_VERSION: unknown"
+        echo "DF_VERSION_VALID: unknown"
+        DF_VERSION_FOUND="Unknown"
+    else
+        DF_VERSION_FOUND="${df_version}"
+        echo "DF_VERSION: ${df_version}"
+        logger info "Detected Data Foundation version: ${df_version}"
+        
+        # Validate version meets minimum requirement
+        local min_df_version="${DATA_FOUNDATION_MIN_VERSION:-4.20.0}"
+        if ! version_compare "${df_version}" "${min_df_version}"; then
+            logger error "Data Foundation version ${df_version} is below minimum required version ${min_df_version}"
+            echo "DF_VERSION_VALID: false"
+            return 1
+        fi
+        
+        echo "DF_VERSION_VALID: true"
+        logger success "Data Foundation version validation passed: ${df_version} >= ${min_df_version}"
+    fi
+    
+    echo "DF_INSTALLED: true"
+    echo "DF_STATUS: ${df_status}"
+    echo "DF_READY: true"
+    logger success "Data Foundation validation passed"
+    
+    return 0
+}
+
+#----------------------------------------
+# Function: Validate CAS installation and version
+#----------------------------------------
+validate_cas() {
+    logger info "Validating Content Aware Storage (CAS) installation..."
+    
+    # Check if CAS namespace exists
+    if ! oc get namespace "${CAS_NAMESPACE}"; then
+        logger error "CAS namespace ${CAS_NAMESPACE} not found"
+        echo "CAS_INSTALLED: false"
+        CAS_VERSION_FOUND="N/A"
+        CAS_STATUS_FOUND="N/A"
+        return 1
+    fi
+    
+    # Check if CAS service instance exists
+    local cas_instance
+    cas_instance=$(oc get FusionServiceInstance -n "${FUSION_NAMESPACE}" --no-headers | awk '{print $1}' | grep ibm-cas-service-instance)
+    
+    if [[ -z "${cas_instance}" ]]; then
+        logger error "CAS service instance not found in namespace ${FUSION_NAMESPACE}"
+        echo "CAS_INSTALLED: false"
+        CAS_VERSION_FOUND="N/A"
+        CAS_STATUS_FOUND="N/A"
+        return 1
+    fi
+    
+    echo "CAS_INSTANCE_NAME: ${cas_instance}"
+    
+    # Check CAS installation status
+    local cas_status
+    cas_status=$(oc get FusionServiceInstance "${cas_instance}" -n "${FUSION_NAMESPACE}" \
+        -o jsonpath='{.status.installStatus.status}' 2>/dev/null)
+    CAS_STATUS_FOUND="${cas_status}"
+    
+    if [[ "${cas_status}" != "Completed" ]]; then
+        logger error "CAS installation status is '${cas_status}', expected 'Completed'"
+        echo "CAS_STATUS: ${cas_status}"
+        echo "CAS_READY: false"
+        return 1
+    fi
+    
+    # Get CAS version
+    local cas_version
+    cas_version=$(oc get FusionServiceInstance "${cas_instance}" -n "${FUSION_NAMESPACE}" \
+        -o jsonpath='{.status.currentVersion}')
+    logger info "${cas_version}"
+    if [[ -z "${cas_version}" ]]; then
+        logger warn "Unable to determine CAS version, proceeding with caution"
+        echo "CAS_VERSION: unknown"
+        echo "CAS_VERSION_VALID: unknown"
+        CAS_VERSION_FOUND="Unknown"
+    else
+        CAS_VERSION_FOUND="${cas_version}"
+        echo "CAS_VERSION: ${cas_version}"
+        logger info "Detected CAS version: ${cas_version}"
+        
+        # Validate version meets minimum requirement
+        local min_cas_version="${CAS_MIN_VERSION:-1.1.3}"
+        if ! version_compare "${cas_version}" "${min_cas_version}"; then
+            logger error "CAS version ${cas_version} is below minimum required version ${min_cas_version}"
+            echo "CAS_VERSION_VALID: false"
+            return 1
+        fi
+        
+        echo "CAS_VERSION_VALID: true"
+        logger success "CAS version validation passed: ${cas_version} >= ${min_cas_version}"
+    fi
+    
+    echo "CAS_INSTALLED: true"
+    echo "CAS_STATUS: ${cas_status}"
+    echo "CAS_READY: true"
+    logger success "CAS validation passed"
+    
+    return 0
+}
+
+#----------------------------------------
+# Function: Validate local cache filesystem exists
+#----------------------------------------
+validate_cache_filesystem() {
+    logger info "Validating local cache filesystem..."
+    
+    # Check if Scale namespace exists
+    if ! oc get namespace "${SCALE_NAMESPACE}"; then
+        logger error "Scale namespace ${SCALE_NAMESPACE} not found"
+        echo "CACHE_FS_EXISTS: false"
+        FS_NAME_FOUND="N/A"
+        FS_CAPACITY_FOUND="N/A"
+        return 1
+    fi
+    
+    # Check if filesystem exists
+    local fs_name="${FILESYSTEM_NAME}"
+    FS_NAME_FOUND="${fs_name}"
+    
+    if ! oc get filesystem "${fs_name}" -n "${SCALE_NAMESPACE}" &>/dev/null; then
+        logger error "Cache filesystem '${fs_name}' not found in namespace ${SCALE_NAMESPACE}"
+        echo "CACHE_FS_EXISTS: false"
+        echo "CACHE_FS_NAME: ${fs_name}"
+        FS_CAPACITY_FOUND="N/A"
+        return 1
+    fi
+    
+    # Check filesystem status
+    local fs_success fs_healthy fs_success_reason fs_healthy_reason
+    fs_success=$(oc get filesystem "${fs_name}" -n "${SCALE_NAMESPACE}" \
+        -o jsonpath='{.status.conditions[?(@.type=="Success")].status}')
+    fs_success_reason=$(oc get filesystem "${fs_name}" -n "${SCALE_NAMESPACE}" \
+        -o jsonpath='{.status.conditions[?(@.type=="Success")].reason}')
+    fs_healthy=$(oc get filesystem "${fs_name}" -n "${SCALE_NAMESPACE}" \
+        -o jsonpath='{.status.conditions[?(@.type=="Healthy")].status}')
+    fs_healthy_reason=$(oc get filesystem "${fs_name}" -n "${SCALE_NAMESPACE}" \
+        -o jsonpath='{.status.conditions[?(@.type=="Healthy")].reason}')
+    
+    if [[ "${fs_success}" != "True" ]]; then
+        if [[ "${fs_success_reason}" != "NotSupported" ]]; then
+            logger error "Cache filesystem '${fs_name}' is not healthy (Success=${fs_success}, Healthy=${fs_healthy})"
+            echo "CACHE_FS_EXISTS: true"
+            echo "CACHE_FS_NAME: ${fs_name}"
+            echo "CACHE_FS_SUCCESS: false"
+            echo "CACHE_FS_SUCCESS_REASON: ${fs_success_reason}"
+            return 1
+        fi
+    fi
+
+    if [[ "${fs_healthy}" != "True" ]]; then
+        if [[ "${fs_healthy_reason}" != "NotSupported" ]]; then
+            logger error "Cache filesystem '${fs_name}' is not healthy (Success=${fs_success}, Healthy=${fs_healthy})"
+            echo "CACHE_FS_EXISTS: true"
+            echo "CACHE_FS_NAME: ${fs_name}"
+            echo "CACHE_FS_HEALTHY: false"
+            echo "CACHE_FS_HEALTHY_REASON: ${fs_healthy_reason}"
+            return 1
+        fi
+    fi
+    
+    # Get filesystem capacity
+    local fs_capacity
+    fs_capacity=$(oc get filesystem "${fs_name}" -n "${SCALE_NAMESPACE}" \
+        -o jsonpath='{.spec.localDiskCapacity}')
+    FS_CAPACITY_FOUND="${fs_capacity:-N/A}"
+    
+    echo "CACHE_FS_EXISTS: true"
+    echo "CACHE_FS_NAME: ${fs_name}"
+    echo "CACHE_FS_SUCCESS: true"
+    echo "CACHE_FS_SUCCESS_REASON: ${fs_success_reason}"
+    echo "CACHE_FS_HEALTHY: true"
+    echo "CACHE_FS_HEALTHY_REASON: ${fs_healthy_reason}"
+    echo "CACHE_FS_CAPACITY: ${fs_capacity}"
+    
+    logger success "Cache filesystem validation passed: '${fs_name}' is healthy with capacity ${fs_capacity}"
+    
+    return 0
+}
+
+#----------------------------------------
+# Function: Validate S3 datasources using cache filesystem
+#----------------------------------------
+validate_s3_datasources() {
+    logger info "Validating S3 datasources using cache filesystem..."
+    
+    local fs_name="${FILESYSTEM_NAME}"
+    local datasource_count=0
+    local valid_datasources=""
+    
+    # Get all datasources in CAS namespace
+    local datasources
+    datasources=$(oc get datasources -n "${CAS_NAMESPACE}" --no-headers -o custom-columns=NAME:.metadata.name 2>/dev/null)
+    
+    if [[ -z "${datasources}" ]]; then
+        logger warn "No datasources found in namespace ${CAS_NAMESPACE}"
+        S3_COUNT_FOUND="0"
+        echo "S3_DATASOURCES_COUNT: 0"
+        echo "S3_DATASOURCES_VALID: false"
+        return 2
+    fi
+    
+    # Check each datasource for S3 type and cache-fs usage.
+    # S3 datasources have spec.s3 populated; the filesystem name is spec.s3.fileSystemName.
+    for ds in ${datasources}; do
+        local ds_cache_fs
+        ds_cache_fs=$(oc get datasource "${ds}" -n "${CAS_NAMESPACE}" \
+            -o jsonpath='{.spec.s3.fileSystemName}')
+        
+        if [[ "${ds_cache_fs}" == "${fs_name}" ]]; then
+            ((datasource_count++))
+            valid_datasources="${valid_datasources}${ds} "
+            logger info "Found valid S3 datasource: ${ds} using cache filesystem ${fs_name}"
+        fi
+    done
+    
+    S3_COUNT_FOUND="${datasource_count}"
+    
+    if [[ ${datasource_count} -eq 0 ]]; then
+        logger error "No S3 datasources found using cache filesystem '${fs_name}'"
+        echo "S3_DATASOURCES_COUNT: 0"
+        echo "S3_DATASOURCES_VALID: false"
+        return 1
+    fi
+    
+    echo "S3_DATASOURCES_COUNT: ${datasource_count}"
+    echo "S3_DATASOURCES_LIST: ${valid_datasources% }"
+    echo "S3_DATASOURCES_VALID: true"
+    
+    logger success "S3 datasource validation passed: Found ${datasource_count} datasource(s) using cache filesystem"
+    
+    return 0
+}
+
+#========================================
+# Main Validation Orchestration
+#========================================
+
+# Global variables to store validation results
+FUSION_VERSION_FOUND=""
+DF_VERSION_FOUND=""
+DF_STATUS_FOUND=""
+CAS_VERSION_FOUND=""
+CAS_STATUS_FOUND=""
+FS_NAME_FOUND=""
+FS_CAPACITY_FOUND=""
+S3_COUNT_FOUND=""
+
+#----------------------------------------
+# Function: Print validation summary table
+#----------------------------------------
+print_validation_summary() {
+    local fusion_status="$1"
+    local df_status="$2"
+    local cas_status="$3"
+    local fs_status="$4"
+    local s3_status="$5"
+    local overall_status="$6"
+    
+    echo ""
+    echo "╔════════════════════════════════════════════════════════════════════════════════════════════════════╗"
+    echo "║                           MIGRATION PREREQUISITES VALIDATION SUMMARY                               ║"
+    echo "╠════════════════════════════════════════════════════════════════════════════════════════════════════╣"
+    echo "║ Component                                     Status                      Details                  ║"
+    echo "╠════════════════════════════════════════════════════════════════════════════════════════════════════╣"
+    printf "║ %-45s %-27s %-25s ║\n" "IBM Spectrum Fusion" "${fusion_status}" "v${FUSION_VERSION_FOUND}"
+    printf "║ %-45s %-27s %-25s ║\n" "OpenShift Data Foundation" "${df_status}" "v${DF_VERSION_FOUND} (${DF_STATUS_FOUND})"
+    printf "║ %-45s %-27s %-25s ║\n" "Content Aware Storage (CAS)" "${cas_status}" "v${CAS_VERSION_FOUND} (${CAS_STATUS_FOUND})"
+    printf "║ %-45s %-27s %-25s ║\n" "Local Cache Filesystem" "${fs_status}" "${FS_NAME_FOUND} (${FS_CAPACITY_FOUND:-N/A})"
+    printf "║ %-45s %-27s %-25s ║\n" "S3 Datasources" "${s3_status}" "${S3_COUNT_FOUND} datasource(s)"
+    echo "╠════════════════════════════════════════════════════════════════════════════════════════════════════╣"
+    printf "║ %-45s %-27s %-25s ║\n" "OVERALL VALIDATION" "${overall_status}" ""
+    echo "╚════════════════════════════════════════════════════════════════════════════════════════════════════╝"
+    echo ""
+}
+
+#----------------------------------------
+# Function: Run all validations
+#----------------------------------------
+run_all_validations() {
+    local overall_status=0
+    local failed_checks=""
+    
+    # Track individual check results for summary
+    local fusion_result="✅ PASSED"
+    local df_result="✅ PASSED"
+    local cas_result="✅ PASSED"
+    local fs_result="✅ PASSED"
+    local s3_result_text="✅ PASSED"
+    
+    logger info "Starting migration prerequisites validation..."
+    logger info "================================================"
+    
+    # Run each validation
+    if ! validate_fusion; then
+        overall_status=1
+        failed_checks="${failed_checks}Fusion "
+        fusion_result="❌ FAILED"
+    fi
+    
+    if ! validate_data_foundation; then
+        overall_status=1
+        failed_checks="${failed_checks}Data Foundation "
+        df_result="❌ FAILED"
+    fi
+    
+    if ! validate_cas; then
+        overall_status=1
+        failed_checks="${failed_checks}CAS "
+        cas_result="❌ FAILED"
+    fi
+    
+    if ! validate_cache_filesystem; then
+        overall_status=1
+        failed_checks="${failed_checks}Cache Filesystem "
+        fs_result="❌ FAILED"
+    fi
+    
+    local s3_exit_code=0
+    validate_s3_datasources || s3_exit_code=$?
+    
+    # S3 datasources might return WARNING (2), only fail on FAILED (1)
+    if [[ ${s3_exit_code} -eq 1 ]]; then
+        overall_status=1
+        failed_checks="${failed_checks}S3 Datasources "
+        s3_result_text="❌ FAILED"
+    elif [[ ${s3_exit_code} -eq 2 ]]; then
+        s3_result_text="❓ WARNING"
+    fi
+    
+    logger info "================================================"
+    
+    # Print summary table
+    local overall_result
+    if [[ ${overall_status} -eq 0 ]]; then
+        overall_result="✅ PASSED"
+    else
+        overall_result="❌ FAILED"
+    fi
+    
+    print_validation_summary "${fusion_result}" "${df_result}" "${cas_result}" "${fs_result}" "${s3_result_text}" "${overall_result}"
+    
+    # Display final validation status
+    if [[ ${overall_status} -eq 0 ]]; then
+        echo "VALIDATION_STATUS: PASSED"
+        echo "VALIDATION_COMPLETED_AT: $(date +"%Y-%m-%d %H:%M:%S")"
+        logger success "All migration prerequisites validation checks PASSED"
+        return 0
+    else
+        echo "VALIDATION_STATUS: FAILED"
+        echo "VALIDATION_FAILED_CHECKS: ${failed_checks% }"
+        echo "VALIDATION_COMPLETED_AT: $(date +"%Y-%m-%d %H:%M:%S")"
+        logger error "Migration prerequisites validation FAILED"
+        logger error "Failed checks: ${failed_checks% }"
+        return 1
+    fi
+}
+
+#========================================
+# Main Entry Point
+#========================================
+
+main() {
+    logger info "Migration Prerequisites Validation Script"
+    
+    # Run all validations
+    run_all_validations
+    rc=$?
+    exit ${rc}
+}
+
+# Execute main function
+main "$@"

--- a/CAS/local-data-caching/bin/setup-data-cache.sh
+++ b/CAS/local-data-caching/bin/setup-data-cache.sh
@@ -12,6 +12,8 @@ source "$ROOT_DIR/lib/constants.sh"
 source "$ROOT_DIR/config/config.env"
 set +a
 
+# shellcheck source=lib/logging.sh
+source "$ROOT_DIR/lib/logging.sh"
 # shellcheck source=lib/utils.sh
 source "$ROOT_DIR/lib/utils.sh"
 
@@ -54,10 +56,9 @@ source "$ROOT_DIR/modules/cas_utils.sh"
 
 # Main function
 main() {
+	# ── SHARED: Prerequisites ──────────────────────────────────────────────
 	logger info "Checking prerequisites..."
-
 	check_ocp_connection
-
 	OCP_VERSION=$(get_ocp_version)
 	export OCP_VERSION
 	is_supported_ocp_version "${OCP_VERSION}"
@@ -69,10 +70,31 @@ main() {
 	fi
 
 	env_type="$(get_environment_type)"
+	logger info "Detected env type: ${env_type}."
 
-	logger info "Detected env type: ${env_type}." # Checking HCI vs SDS
+	# ── SHARED: Version Discovery ──────────────────────────────────────────
+	fusion_installed="$(get_fusion_version)"
+	fusion_ver="${fusion_installed:-$FUSION_VERSION}"
+	logger info "Fusion version in use: ${fusion_ver} (installed: ${fusion_installed:-none})"
 
-	# # Install fusion if not already installed
+	odf_installed="$(get_odf_version)"
+	odf_ver="${odf_installed:-$ODF_VERSION}"
+	logger info "ODF version in use: ${odf_ver} (installed: ${odf_installed:-none})"
+
+	cnsa_installed="$(get_cnsa_version)"
+	# CNSA_VERSION is in product format (6.0.1.0); transform to CSV format (60.1.0) for comparison
+	cnsa_ver="${cnsa_installed:-$(cnsa_product_to_csv "$CNSA_VERSION")}"
+	logger info "CNSA version in use: ${cnsa_ver} (installed: ${cnsa_installed:-none})"
+
+	cas_installed="$(get_cas_version)"
+	# CAS_VERSION may have a leading 'v'; strip it for consistency with get_cas_version output
+	cas_ver="${cas_installed:-${CAS_VERSION#v}}"
+	logger info "CAS version in use: ${cas_ver} (installed: ${cas_installed:-none})"
+
+	CNSA_GTE_6010=$(version_gte "${cnsa_ver}" "60.1.0")
+	CAS_GTE_115=$(version_gte "${cas_ver}" "1.1.5")
+
+	# ── FUSION: Discover or use target version ─────────────────────────────
 	if [[ "${env_type}" == "${SDS_ENVIRONMENT}" ]]; then
 		if [[ -z "$(is_operator_installed "$FUSION_PACKAGE_NAME")" ]]; then
 			deploy_fusion "${env_type}"
@@ -81,7 +103,7 @@ main() {
 		fi
 	fi
 
-	# # Apply spectrum fusion CR if not present
+	# Apply spectrum fusion CR if not present
 	if ! ensure_spectrum_fusion; then
 		logger info "Spectrum Fusion CR not found. Applying..."
 		apply_spectrum_fusion
@@ -89,7 +111,7 @@ main() {
 		logger success "Spectrum Fusion CR already present in namespace '$FUSION_NAMESPACE'."
 	fi
 
-	# # Install FDF if not already installed
+	# ── DATA FOUNDATION: Discover or use target version ────────────────────
 	if [[ -z "$(is_fsi_deployed "$DF_SERVICE_NAME")" ]]; then
 		deploy_fsi "$DF_SERVICE_NAME" "templates/fusion/data_foundation.yaml"
 	else
@@ -98,7 +120,6 @@ main() {
 
 	wait_for_fsi "$DF_SERVICE_NAME" "templates/fusion/data_foundation.yaml"
 
-	# Configure FDF if not already configured
 	if [[ -z "$(is_fdf_configured)" ]]; then
 		logger info "FDF not configured or not Ready. Configuring now..."
 		configure_fdf
@@ -110,7 +131,22 @@ main() {
 
 	create_scale_rbd_sc
 
-	# Create scale cluster if not exist
+	# ── CNSA: Discover or use target version ──────────────────────────────
+	if [[ "${CNSA_GTE_6010}" == false ]]; then
+		# < 6.0.1.0: Scale is FSI-managed, manual PVC + daemonset + RBD SC
+		if is_scale_deployed; then
+			logger success "IBM Storage Scale is already deployed."
+		else
+			logger info "IBM Storage Scale not detected. Deploying..."
+			deploy_scale_service
+		fi
+
+		ensure_project "$LOCAL_STORAGE_PROJECT"
+		create_pvc_local_disks
+		create_expose_rbd_daemonset
+	fi
+
+	# ── SHARED: Scale cluster ──────────────────────────────────────────────
 	if ! is_scale_cluster_created; then
 		SCALE_CLUSTER_NAME="${SCALE_CLUSTER_NAME:-$(get_cluster_base_domain)}"
 		create_scale_cluster
@@ -118,12 +154,35 @@ main() {
 
 	verify_scale_cluster
 
-	create_scale_rbd_sc
+	# ── Filesystem Creation: version-gated ──────────────────────────────────
+	if [[ "${CAS_GTE_115}" == false ]] || [[ "${CNSA_GTE_6010}" == false ]]; then
+		if ! is_fs_created; then
+			logger info "Configuring CNSA with $FILESYSTEM_NAME filesystem and $FILESYSTEM_CAPACITY size..."
+			create_fs "${CNSA_GTE_6010}"
+		fi
 
-	# HACK: Workaround for missing cas-operator RBAC for labeling nodes
-	ensure_node_labeling_rbac
+		verify_fs
+		patch_scale_csi_driver
 
-	# Install CAS if not already installed
+		if [[ "${CNSA_GTE_6010}" == false ]]; then
+			validate_local_disks_usage
+		fi
+	fi
+
+	if [[ "${CAS_GTE_115}" == false ]]; then
+		configure_afm
+		verify_afm_config
+		scale_set_config "syncReadWFConfig" "yes"
+		scale_set_config "afmPtrashOpt" "3"
+		logger success "Scale AFM config set"
+	fi
+
+	if [[ "${CAS_GTE_115}" == true ]]; then
+		# HACK: Workaround for missing cas-operator RBAC for labeling nodes
+		ensure_node_labeling_rbac
+	fi
+
+	# ── SHARED: CAS deploy ─────────────────────────────────────────────────
 	if [[ -z "$(is_fsi_deployed "$CAS_SERVICE_NAME")" ]]; then
 		patch_cas_fsd
 		deploy_fsi "${CAS_SERVICE_NAME}" "templates/fusion/content_aware_storage.yaml"
@@ -134,13 +193,19 @@ main() {
 	wait_for_casinstall "${CAS_NAMESPACE}" "${CAS_SERVICE_NAME}"
 
 	logger info "Patching CasInstall"
-	patch_cas_install "${CAS_NAMESPACE}" "${CAS_SERVICE_NAME}"
+	patch_cas_install "${CAS_NAMESPACE}" "${CAS_SERVICE_NAME}" "${CAS_GTE_115}" "${CNSA_GTE_6010}"
 
-	patch_scale_csi_driver
-
-	wait_for_fsi "${CAS_SERVICE_NAME}" "templates/fusion/content_aware_storage.yaml" "${CAS_SERVICE_TIMEOUT}"
-
-	delete_scale_rbd_sc
+	# ── Post-CAS-install: version-gated ───────────────────────────────────
+	if [[ "${CAS_GTE_115}" == true ]]; then
+		patch_scale_csi_driver
+		wait_for_fsi "${CAS_SERVICE_NAME}" "templates/fusion/content_aware_storage.yaml" "${CAS_SERVICE_TIMEOUT}"
+		verify_cas_install
+	else
+		wait_for_fsi "${CAS_SERVICE_NAME}" "templates/fusion/content_aware_storage.yaml" "${CAS_SERVICE_TIMEOUT}"
+		delete_scale_rbd_sc
+		configure_scale_watch "${CAS_NAMESPACE}" "${FILESYSTEM_NAME}"
+		logger success "Scale watch configured"
+	fi
 
 	logger success "Local Data Caching has been successfully configured for CAS! 🎉"
 }

--- a/CAS/local-data-caching/config/config.env
+++ b/CAS/local-data-caching/config/config.env
@@ -17,6 +17,11 @@ source "$SCRIPT_DIR/../lib/constants.sh"
 [[ -f .env ]] && source .env
 
 #========================================
+# Logging
+#========================================
+LOG_TO_FILE="${LOG_TO_FILE:-true}"
+
+#========================================
 # OCP Parameters
 #========================================
 QUORUM_NODE_SELECTOR_LABEL="${QUORUM_NODE_SELECTOR_LABEL:-$CONTROL_ROLE}"
@@ -27,7 +32,7 @@ KUBELET_ROOT_DIR_PATH="${KUBELET_ROOT_DIR_PATH:-/var/lib/kubelet}"
 #========================================
 
 FUSION_CATALOG_NAME="${FUSION_CATALOG_NAME:-"isf-operator-catalog"}"
-FUSION_VERSION="${FUSION_VERSION:-2.12.0}"
+FUSION_VERSION="${FUSION_VERSION:-2.13.0}"
 CAS_VERSION="${CAS_VERSION:-v1.1}"
 
 # Namespace where Fusion operator will be installed
@@ -49,6 +54,7 @@ INSTALL_STRATEGY="${INSTALL_STRATEGY:-Automatic}"
 #   "In:region=us-east,us-west"
 #   "Exists:node-role.kubernetes.io/worker;NotIn:beta.kubernetes.io/instance-type=gx3d.160x1792.8h100"
 
+ODF_VERSION="${ODF_VERSION:-4.21}"
 STORAGE_NODE_MATCH="${STORAGE_NODE_MATCH:-${WORKER_MATCH}}"
 
 # Project name to mount RBD volumes as local disks
@@ -60,6 +66,7 @@ ODF_ALLOW_ROTATIONAL="${ODF_ALLOW_ROTATIONAL:-false}"
 #========================================
 # Spectrum Scale Parameters
 #========================================
+CNSA_VERSION="${CNSA_VERSION:-6.0.1.0}"
 SCALE_NAMESPACE="${SCALE_NAMESPACE:-ibm-spectrum-scale}"
 SCALE_CSI_NAMESPACE="${SCALE_CSI_NAMESPACE:-${SCALE_NAMESPACE}-csi}"
 SCALE_OPERATOR_NAMESPACE="${SCALE_OPERATOR_NAMESPACE:-${SCALE_NAMESPACE}-operator}"
@@ -83,3 +90,6 @@ CAS_RHAI_USE_CPU="${CAS_RHAI_USE_CPU:-false}"
 CAS_INSTALL_TIMEOUT="${CAS_INSTALL_TIMEOUT:-300}"
 CAS_SERVICE_TIMEOUT="${CAS_SERVICE_TIMEOUT:-}"
 CAS_CLEANUP_SCRIPT_URL="${CAS_CLEANUP_SCRIPT_URL:-https://raw.githubusercontent.com/IBM/storage-fusion/refs/heads/master/CAS/cas-cleanup/customer_cas_cleanup.sh}"
+RELATED_IMAGE_CAS_DOCLING_CPU="${RELATED_IMAGE_CAS_DOCLING_CPU:-}"
+RELATED_IMAGE_CAS_VLLM_CPU="${RELATED_IMAGE_CAS_VLLM_CPU:-}"
+CAS_ENABLE_DOCLING="${CAS_ENABLE_DOCLING:-true}"

--- a/CAS/local-data-caching/docs/KNOWN_ISSUES.md
+++ b/CAS/local-data-caching/docs/KNOWN_ISSUES.md
@@ -1,0 +1,45 @@
+# Known Issues and Manual Workarounds
+
+This document describes known issues that require manual intervention and have no automated
+fix at this time.
+
+> **Note:** Workarounds marked *Recurrent* must be re-applied on every CAS install or upgrade.
+> Workarounds marked *Non-Recurrent* are applied once to the cluster and persist.
+
+---
+
+## Workaround Index
+
+| # | Title | Recurrence |
+|---|-------|------------|
+| [W001](workarounds/W001-eventmanager-networkpolicy.md) | CAS operator reconcile stalls ~60 s — missing EventManager NetworkPolicy | Non-Recurrent |
+| [W002](workarounds/W002-fsgroup-scc-override.md) | docling / vllm / cast-runtime CrashLoopBackOff or permission denied — SCC fsGroup override | Non-Recurrent |
+| [W003](workarounds/W003-kafka-version-unsupported.md) | Upgrade stalls — Kafka CR patched to unsupported version | Recurrent |
+| [W004](workarounds/W004-kafka-certs-job-loop.md) | CAS upgrade never completes — Kafka certs job deleted and recreated in a loop | Recurrent |
+| [W005](workarounds/W005-schema-init-ttl-requeue-loop.md) | Schema-init job requeue loop — cast-runtime Deployment never updated | Recurrent |
+| [W006](workarounds/W006-cast-runtime-stale-pvc.md) | cast-runtime pod Pending — stale PVC reference after DataSource recreate | Recurrent |
+
+## Ordered Application Sequence
+
+Apply workarounds in phase order. Within each phase apply them top-to-bottom.
+
+### Phase 0 — Pre-Install *(apply once, before CAS installation starts)*
+
+| Workaround | When |
+|------------|------|
+| [W001 — EventManager NetworkPolicy](workarounds/W001-eventmanager-networkpolicy.md) | Before CAS install begins |
+| [W002 — SCC fsGroup Override](workarounds/W002-fsgroup-scc-override.md) | Before DocumentProcessor / vllm / docling pods first start |
+
+### Phase 1 — Post-Cache-Enable *(apply after `setup-data-cache.sh` exits, CAS 1.1.5 only)*
+
+| Workaround | When |
+|------------|------|
+| [W003 — Kafka Version](workarounds/W003-kafka-version-unsupported.md) | Before triggering install re-entry (before W004 if both apply) |
+| [W004 — Kafka Certs Job Loop](workarounds/W004-kafka-certs-job-loop.md) | After `spec.cache` confirmed set; within the window the certs job is `Succeeded` |
+
+### Phase 2 — Post-Migration *(apply after a restore that causes DataSource deletion)*
+
+| Workaround | When |
+|------------|------|
+| [W005 — Schema-Init Requeue Loop](workarounds/W005-schema-init-ttl-requeue-loop.md) | Within 5 minutes of schema-init job completing |
+| [W006 — Stale PVC Reference](workarounds/W006-cast-runtime-stale-pvc.md) | After W005 is resolved and cast-runtime pod is still `Pending` |

--- a/CAS/local-data-caching/docs/MIGRATION.md
+++ b/CAS/local-data-caching/docs/MIGRATION.md
@@ -1,0 +1,81 @@
+# CAS Data Cache Migration
+
+This migration is required when upgrading from CAS 1.1.4 to CAS 1.1.5 if you have an existing local Filesystem cache configured in CAS 1.1.4.
+
+## Usage
+
+```bash
+./bin/migrate-data-cache.sh --migration-phase <phase> [OPTIONS]
+```
+
+Run `./bin/migrate-data-cache.sh --help` for the full flag and environment variable reference.
+
+## Prerequisites
+
+- OpenShift cluster connection (`oc login`)
+- Cluster admin privileges
+- CAS 1.1.4+
+- Scale filesystem deployed by `setup-data-cache.sh`
+
+## Migration Phases
+
+| Phase     | Description |
+| --------- | ----------- |
+| `pre`     | Back up DataSources and record migration state before a Fusion/CAS upgrade |
+| `post`    | Restore DataSources from backup after the upgrade completes; removes all migration resources on success |
+| `full`    | Execute `pre` and `post` in sequence; removes all migration resources on success |
+| `cleanup` | Delete all migration resources (Jobs, ConfigMaps, NetworkPolicy, PVC, RBAC) without running a migration Job |
+
+## Workflow
+
+### Standard upgrade
+
+1. Run the `pre` phase before upgrading Fusion or CAS:
+   ```bash
+   ./bin/migrate-data-cache.sh --migration-phase pre
+   ```
+2. Delete the Scale Filesystem, LocalDisk CRs, and local storage namespace:
+   ```bash
+   oc label -n ibm-spectrum-scale filesystem cache-fs scale.spectrum.ibm.com/allowDelete=
+   oc delete filesystem cache-fs -n ibm-spectrum-scale --ignore-not-found
+   oc delete localdisk disk0 disk1 disk2 -n ibm-spectrum-scale --ignore-not-found
+   oc delete namespace local-disk-as-pv --ignore-not-found
+   ```
+   Wait for the filesystem deletion to complete:
+   ```bash
+   oc wait filesystem cache-fs -n ibm-spectrum-scale --for=delete --timeout=300s
+   ```
+3. Perform the Fusion/CAS upgrade.
+4. Run the `post` phase to restore:
+   ```bash
+   ./bin/migrate-data-cache.sh --migration-phase post
+   ```
+
+### Re-running after a failure
+
+If a Job fails, delete it before re-running:
+
+```bash
+DELETE_PREVIOUS_JOBS=true ./bin/migrate-data-cache.sh --migration-phase pre
+```
+
+### Teardown
+
+To remove all migration resources after a confirmed complete migration:
+
+```bash
+PRESERVE_JOB_RESOURCES=false ./bin/migrate-data-cache.sh --migration-phase cleanup
+```
+
+## Environment Variables
+
+| Variable                    | Default  | Description |
+| --------------------------- | -------- | ----------- |
+| `DELETE_PREVIOUS_JOBS`      | `false`  | Delete existing Jobs for the phase before running (required to re-run after failure) |
+| `PRESERVE_JOB_RESOURCES`    | `true`   | When `false`, delete all migration resources on exit |
+
+## Running Tests
+
+```bash
+./tests/test_migrate_cas_filesystem.sh
+```

--- a/CAS/local-data-caching/docs/TROUBLESHOOTING.md
+++ b/CAS/local-data-caching/docs/TROUBLESHOOTING.md
@@ -1,0 +1,75 @@
+# Troubleshooting
+
+## Image Pull Errors
+
+- Check pod events for failures.
+- Verify manifests for IDMS/ITMS issues.
+- Ensure pull secrets are valid.
+
+For restricted network environments, see [Offline / Internal Registry Configuration](OFFLINE_REGISTRY.md).
+
+## Leftover Ceph Metadata
+
+If `StorageCluster` is stuck in `Provisioning` phase (e.g., `failed to get device already provisioned by ceph-volume`), clean old Ceph metadata: [Red Hat Solution 7115651](https://access.redhat.com/solutions/7115651).
+
+After cleanup, wait for the storage cluster to reach `Ready` phase:
+
+```bash
+oc get storagecluster "$OCS_CLUSTER_NAME" -n $OCS_NAMESPACE -o jsonpath='{.status.phase}'
+```
+
+## IBM Spectrum Scale Webhook Issues
+
+If webhook errors occur (`no endpoints available for service "ibm-spectrum-scale-controller-manager-service"`), check for duplicate or conflicting webhooks and set `failurePolicy: Ignore` to disable the webhook.
+
+## LocalDisks In Use
+
+If a disk is reported as already in use, set `skipVerify: true` in the `LocalDisk` CR in the `$SCALE_NAMESPACE` namespace.
+
+## Node Draining / Stuck Node Issues
+
+If an upgrade or node drain process appears to be stuck, refer to the following documentation:
+- [Troubleshooting blocked upgrades and blocked node drains](https://www.ibm.com/docs/en/scalecontainernative/6.0.1?topic=troubleshooting-blocked-upgrades-blocked-node-drains)
+- [Draining nodes](https://www.ibm.com/docs/en/scalecontainernative/6.0.1?topic=nodes-draining)
+
+Checking the Pod logs in the `openshift-machine-config-operator` Namespace can also help reveal additional information.
+
+## Scale Container Native Lingering Files and Kernel Modules
+
+If a previous installation of Scale Container Native was not cleanly uninstalled, it could lead to a stale or failed kernel module load on one or more nodes. To resolve this, it may be necessary to reboot the OpenShift nodes to bring the system back to a clean state.
+
+- Only reboot one node at a time, and wait for it to come back `Ready` before proceeding to another node.
+- See the [Scale Container Native documentation](https://www.ibm.com/docs/en/scalecontainernative/6.0.1?topic=cleanup) for complete cleanup instructions.
+
+## Namespace Stuck in Terminating
+
+If a Namespace (e.g. `ibm-cas`) is stuck in `Terminating`, CRs with finalizers are blocking deletion. Identify and patch them:
+
+```bash
+# Find all CRs in ibm-cas with finalizers
+for crd in $(oc api-resources --verbs=list --namespaced -o name 2>/dev/null); do
+  items=$(oc get "${crd}" -n ibm-cas \
+    -o jsonpath='{range .items[?(@.metadata.finalizers)]}{.metadata.name}{" ("}{.kind}{")"}{ "\n"}{end}' 2>/dev/null)
+  [[ -n "${items}" ]] && echo "${items}"
+done
+
+# Remove finalizers from each stuck CR:
+oc patch <kind> <name> -n ibm-cas \
+  --type=json -p='[{"op":"remove","path":"/metadata/finalizers"}]'
+```
+
+Once all finalizers are cleared the namespace will finish terminating. Wait before re-running setup:
+
+```bash
+oc wait namespace ibm-cas --for=delete --timeout=120s
+```
+
+## Scale Daemon Timeout with ODF ≥ 4.21.0
+
+If `setup-data-cache.sh` exits with `Timeout: Scale Daemon did not come up within 300s` on a cluster running ODF 4.21.0 or higher, the `odf-operator-controller-manager` pod has failed to scale up the Scale operator Deployment. Restart it and re-run setup:
+
+```bash
+oc rollout restart deployment/odf-operator-controller-manager -n openshift-storage
+oc rollout status deployment/odf-operator-controller-manager -n openshift-storage --timeout=120s
+./bin/setup-data-cache.sh
+```

--- a/CAS/local-data-caching/docs/workarounds/W001-eventmanager-networkpolicy.md
+++ b/CAS/local-data-caching/docs/workarounds/W001-eventmanager-networkpolicy.md
@@ -1,0 +1,74 @@
+# W001 — CAS Operator Reconcile Stalls: Missing EventManager NetworkPolicy
+
+**Recurrence:** Non-Recurrent — apply once before CAS installation; persists across installs
+and upgrades unless `isf-serviceability-operator` reconciles it away.
+
+---
+
+## Symptom
+
+The CAS operator logs repeat the following pattern approximately every 60 seconds throughout
+the entire install and any subsequent reconcile:
+
+```
+Event Manager service url: https://<clusterIP>:10666/api/v1/eventmanager/alerts
+Error POSTing info request (...): Post "https://<clusterIP>:10666/api/v1/eventmanager/alerts":
+  context deadline exceeded (Client.Timeout exceeded while awaiting headers)
+```
+
+Each timeout adds ~60 s of dead time to every reconcile cycle, visibly slowing install and
+upgrade progress.
+
+## Root Cause
+
+The `eventmanager-network-policy` in `ibm-spectrum-fusion-ns` has no ingress rule permitting
+traffic from the `ibm-cas` namespace to port `10666`. Every outbound POST from the CAS
+operator is silently dropped and the HTTP client blocks until the OS TCP timeout expires.
+
+## When to Apply
+
+**Before CAS installation begins.** Every reconcile cycle stalls without this.
+
+Re-apply if the symptom returns after an `isf-serviceability-operator` reconcile overwrites
+the policy.
+
+## Steps
+
+Save the following manifest and apply it:
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-cas-operator-to-eventmanager
+  namespace: ibm-spectrum-fusion-ns
+  labels:
+    app.kubernetes.io/managed-by: cas-operator
+spec:
+  podSelector:
+    matchLabels:
+      app: isfemdep
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: ibm-cas
+      podSelector:
+        matchLabels:
+          app.kubernetes.io/component: operator
+          app.kubernetes.io/name: cas.isf.ibm.com
+    ports:
+    - port: 10666
+      protocol: TCP
+```
+
+```bash
+oc apply -f allow-cas-operator-to-eventmanager.yaml
+```
+
+## Verify
+
+After applying, operator logs should no longer show `context deadline exceeded` for Event
+Manager POST calls.

--- a/CAS/local-data-caching/docs/workarounds/W002-fsgroup-scc-override.md
+++ b/CAS/local-data-caching/docs/workarounds/W002-fsgroup-scc-override.md
@@ -1,0 +1,132 @@
+# W002 — docling / vllm / cast-runtime CrashLoopBackOff: SCC fsGroup Override
+
+**Recurrence:** Non-Recurrent — apply once before affected pods first start; persists until
+the SCC or RBAC is removed.
+
+---
+
+## Symptom
+
+After a CAS upgrade (or on a fresh install), one or more of the following are observed:
+
+- `docling` pod is `1/2 CrashLoopBackOff`. Logs show:
+  ```
+  FileNotFoundError: .../ch_PP-OCRv4_det_mobile.onnx does not exist
+  ```
+  A stale `huggingface-model-data` PVC contains `_infer`-suffix model files; CAS 1.1.5
+  expects `_mobile`-suffix files.
+
+- `vllm-embedding` or `vllm-vision` pods are `1/2 CrashLoopBackOff`. Logs show:
+  ```
+  PermissionError: [Errno 13] Permission denied: '/models/modules'
+  ```
+
+- `cast-runtime` pod logs show:
+  ```
+  Error publishing messages [Errno 13] Permission denied: '/shared/<jobID>'
+  ```
+  Inside the pod:
+  ```bash
+  $ stat /shared
+  Access: (0755/drwxr-xr-x)  Uid: (0/root)  Gid: (0/root)
+  ```
+
+## Root Cause
+
+`ibm-cas-setuid-setgid-scc` is configured with `fsGroup: RunAsAny` (priority 10). When this
+SCC wins pod admission, the kubelet skips fsGroup injection entirely and does not chown
+volume mounts. PVC mounts remain owned by `root:root`, and pods running as a non-root UID
+cannot write to them.
+
+## When to Apply
+
+**Before the DocumentProcessor, vllm, and docling pods first start.** The SCC must exist at
+pod admission time.
+
+If the affected pods have already started under the wrong SCC, apply all steps below and
+then bounce them (step 4).
+
+## Steps
+
+**Step 1 — Create override SCC** (priority 11 beats the existing SCC at priority 10):
+
+```bash
+oc apply -f - <<'EOF'
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: ibm-cas-cast-runtime-mustrunasgroup
+allowPrivilegeEscalation: false
+allowPrivilegedContainer: false
+allowedCapabilities: [SETUID, SETGID]
+fsGroup:
+  type: MustRunAs
+groups: []
+users: []
+runAsUser:
+  type: MustRunAsNonRoot
+seLinuxContext:
+  type: MustRunAs
+supplementalGroups:
+  type: RunAsAny
+volumes: [configMap, emptyDir, persistentVolumeClaim, secret]
+EOF
+```
+
+**Step 2 — Create ClusterRole:**
+
+```bash
+oc apply -f - <<'EOF'
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: ibm-cas-cast-runtime-mustrunasgroup-use
+rules:
+- apiGroups: [security.openshift.io]
+  resourceNames: [ibm-cas-cast-runtime-mustrunasgroup]
+  resources: [securitycontextconstraints]
+  verbs: [use]
+EOF
+```
+
+**Step 3 — Bind to the relevant service accounts:**
+
+```bash
+oc apply -f - <<'EOF'
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: ibm-cas-cast-runtime-mustrunasgroup-use
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ibm-cas-cast-runtime-mustrunasgroup-use
+subjects:
+- kind: ServiceAccount
+  name: ibm-isf-cas-operator-system
+  namespace: ibm-cas
+- kind: ServiceAccount
+  name: default
+  namespace: ibm-cas
+EOF
+```
+
+**Step 4 — Bounce affected pods** so they are re-admitted under the new SCC:
+
+```bash
+# Replace <domain> with your DocumentProcessor domain name (e.g. deucalion-domain)
+oc delete pod -n ibm-cas \
+  -l app.kubernetes.io/component=cast-runtime,app.kubernetes.io/part-of=<domain>
+oc delete pod -n ibm-cas -l app.kubernetes.io/component=vllm
+oc delete pod -n ibm-cas -l app.kubernetes.io/name=docling
+```
+
+## Verify
+
+After pods restart, confirm they are admitted under the new SCC:
+
+```bash
+oc get pod <pod-name> -n ibm-cas \
+  -o jsonpath='{.metadata.annotations.openshift\.io/scc}{"\n"}'
+# Expected: ibm-cas-cast-runtime-mustrunasgroup
+```

--- a/CAS/local-data-caching/docs/workarounds/W003-kafka-version-unsupported.md
+++ b/CAS/local-data-caching/docs/workarounds/W003-kafka-version-unsupported.md
@@ -1,0 +1,67 @@
+# W003 — Upgrade Stalls: Kafka CR Patched to Unsupported Version
+
+**Recurrence:** Recurrent — must be re-applied each time the CAS operator patches the Kafka
+CR to an unsupported version (i.e., on every install re-entry or upgrade that triggers
+`UpdateKafkaVersion`).
+
+---
+
+## Symptom
+
+After enabling the cache filesystem or triggering any upgrade, the CAS operator logs repeat
+indefinitely:
+
+```
+Kafka not yet ready.
+```
+
+Inspecting the Kafka CR shows:
+
+```bash
+oc get kafka kafka -n ibm-cas -o jsonpath='{.status.conditions}'
+```
+
+```json
+[{
+  "message": "Unsupported Kafka.spec.kafka.version: 3.9.0. Supported versions are: [4.0.0, 4.1.0]",
+  "reason": "UnsupportedKafkaVersionException",
+  "status": "True",
+  "type": "NotReady"
+}]
+```
+
+## Root Cause
+
+The CAS operator hardcodes Kafka version `3.9.0` when patching the Kafka CR during upgrades
+and install re-entry. With AMQ Streams 3.1.0-14, only versions `4.0.0` and `4.1.0` are
+supported. The Kafka CR is immediately set to `NotReady`, and `IsHealthyKafkaCluster` never
+returns `true`.
+
+## When to Apply
+
+**Before triggering install re-entry** (i.e., before applying the CasInstall status patch
+that re-enters the cache filesystem install path). Strimzi needs approximately 30 seconds to
+reconcile the Kafka CR to `Ready` after this patch.
+
+If the operator has already entered the loop, apply the patch and wait for the next
+reconcile cycle to proceed.
+
+## Steps
+
+```bash
+oc patch kafka kafka -n ibm-cas --type=merge \
+  -p '{"spec":{"kafka":{"version":"4.0.0"}}}'
+```
+
+## Verify
+
+Within ~30 seconds, the Kafka CR should show `type=Ready, status=True`:
+
+```bash
+oc get kafka kafka -n ibm-cas \
+  -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}{"\n"}'
+# Expected: True
+```
+
+The operator log should stop repeating `"Kafka not yet ready."` after the next reconcile
+cycle.

--- a/CAS/local-data-caching/docs/workarounds/W004-kafka-certs-job-loop.md
+++ b/CAS/local-data-caching/docs/workarounds/W004-kafka-certs-job-loop.md
@@ -1,0 +1,79 @@
+# W004 — CAS Upgrade Never Completes: Kafka Certs Job Deleted and Recreated in a Loop
+
+**Recurrence:** Recurrent — must be applied on every `1.1.4 → 1.1.5` upgrade where
+`spec.cache` is configured on the CasInstall.
+
+---
+
+## Symptom
+
+After `setup-data-cache.sh` exits with `spec.cache` set on CasInstall, the CAS upgrade from
+1.1.4 to 1.1.5 never completes. `status.version.current` remains `1.1.4`. Operator logs
+show the following pattern repeating:
+
+```
+KafkaCertificates, Job already exists
+KafkaCertificates, Waiting for job to complete
+...
+KafkaCertificates, Job succeeded, deleting it
+KafkaCertificates, Creating Job
+KafkaCertificates, Waiting for job to complete
+```
+
+The `cas-kafka-certs-export-ceph` job is deleted immediately after completion, then
+re-created, looping indefinitely. `AfterUpgrade` hooks and the step that writes
+`status.version.current = 1.1.5` are never reached.
+
+## Root Cause
+
+Two code paths in the upgrade reconciler share the same hardcoded job name
+(`cas-kafka-certs-export-ceph`). When the first path deletes the completed job, the second
+path immediately recreates it. The upgrade can never advance past the job wait.
+
+## When to Apply
+
+**After `setup-data-cache.sh` exits and `spec.cache` is confirmed set on CasInstall.**
+Watch for the `cas-kafka-certs-export-ceph` job to appear and reach `Succeeded` state — the
+finalizer must be added inside that narrow window.
+
+The finalizer must be removed after the upgrade completes (step 4 below).
+
+## Steps
+
+**Step 1 — Watch for the job and add a finalizer while it is in `Succeeded` state:**
+
+```bash
+# Poll until the job exists and is complete, then immediately run:
+oc patch job cas-kafka-certs-export-ceph -n ibm-cas \
+  --type=merge \
+  -p '{"metadata":{"finalizers":["cas.isf.ibm.com/keep-for-upgrade"]}}'
+```
+
+**Step 2 — Wait for the upgrade to complete.** Watch operator logs for:
+
+```
+Upgrade reconciliation is complete
+```
+
+**Step 3 — Confirm the `operator-config` ConfigMap has a valid `KAFKA_AUTHEN_LOCAL` path:**
+
+```bash
+oc get configmap operator-config -n ibm-cas \
+  -o jsonpath='{.data.KAFKA_AUTHEN_LOCAL}{"\n"}'
+# Expected: non-empty path, e.g. /mnt/cache-fs/...
+```
+
+**Step 4 — Remove the finalizer:**
+
+```bash
+oc patch job cas-kafka-certs-export-ceph -n ibm-cas \
+  --type=merge -p '{"metadata":{"finalizers":null}}'
+```
+
+## Verify
+
+```bash
+oc get casinstall ibm-cas-service-instance -n ibm-cas \
+  -o jsonpath='{.status.version.current}{"\n"}'
+# Expected: 1.1.5
+```

--- a/CAS/local-data-caching/docs/workarounds/W005-schema-init-ttl-requeue-loop.md
+++ b/CAS/local-data-caching/docs/workarounds/W005-schema-init-ttl-requeue-loop.md
@@ -1,0 +1,63 @@
+# W005 — Schema-Init Job Requeue Loop: cast-runtime Deployment Never Updated
+
+**Recurrence:** Recurrent — must be applied after every DataSource delete-and-recreate that
+triggers a schema-init job (e.g., after each migration restore).
+
+---
+
+## Symptom
+
+After a DataSource is deleted and recreated (e.g., following a migration restore), the
+cast-runtime pod remains `Pending` and the operator logs repeat:
+
+```
+Created schema initialization job, requeuing  Job=db-schema-init-<domain>
+Requeue requested  reason="requeue requested while waiting for schema job to complete"
+```
+
+The cast-runtime `Deployment` is never updated with the new PVC name. The pod stays
+`Pending` indefinitely.
+
+## Root Cause
+
+The `db-schema-init-<domain>` Job has a 5-minute TTL (`ttlSecondsAfterFinished: 300`).
+After Kubernetes garbage-collects the completed job, the operator has no record that schema
+init already succeeded. On every subsequent reconcile it re-creates the job and returns a
+requeue error before ever reaching the Deployment update step.
+
+## When to Apply
+
+**Within 5 minutes of the `db-schema-init-<domain>` job completing** — before the TTL
+garbage collector fires.
+
+If the 5-minute window is missed, the job will already be gone and the loop will have
+started. In that case:
+
+1. Delete the looping job so the operator recreates it fresh:
+   ```bash
+   oc delete job db-schema-init-<domain> -n ibm-cas
+   ```
+2. Immediately apply the patch below on the newly created job before it completes.
+
+## Steps
+
+```bash
+# Replace <domain> with your domain name (e.g. deucalion-domain)
+oc patch job db-schema-init-<domain> -n ibm-cas --type=json \
+  -p='[{"op":"remove","path":"/spec/ttlSecondsAfterFinished"}]'
+```
+
+## Verify
+
+The operator should stop producing requeue log entries and proceed to update the cast-runtime
+Deployment. The cast-runtime pod should transition from `Pending` to `Running` within a
+minute or two as subsequent reconcile steps complete.
+
+```bash
+oc get pod -n ibm-cas -l app.kubernetes.io/component=cast-runtime
+# Expected: Running
+```
+
+> **Note:** If the cast-runtime pod is still `Pending` after the requeue loop stops, also
+> check for a stale PVC reference in the Deployment — see
+> [W006](W006-cast-runtime-stale-pvc.md).

--- a/CAS/local-data-caching/docs/workarounds/W006-cast-runtime-stale-pvc.md
+++ b/CAS/local-data-caching/docs/workarounds/W006-cast-runtime-stale-pvc.md
@@ -1,0 +1,65 @@
+# W006 — cast-runtime Pod Pending: Stale PVC Reference After DataSource Recreate
+
+**Recurrence:** Recurrent — must be applied after every migration restore that causes a
+DataSource CR to be deleted and recreated with a new PVC name.
+
+---
+
+## Symptom
+
+After a migration restore that causes a DataSource CR to be deleted and recreated, the
+cast-runtime pod stays `Pending`. Pod events show a missing or inaccessible volume. The
+Deployment still references the old (deleted) PVC while the recreated DataSource has
+published a new PVC name:
+
+```bash
+# New PVC as advertised by the DataSource
+oc get datasource <domain>-datasource -n ibm-cas \
+  -o jsonpath='{.metadata.annotations.pvc-name}{"\n"}'
+# prints: <new-pvc-name>
+
+# PVC still in the Deployment (mismatch)
+oc get deployment <cast-deploy> -n ibm-cas \
+  -o jsonpath='{range .spec.template.spec.volumes[*]}{.name}{"="}{.persistentVolumeClaim.claimName}{"\n"}{end}'
+# prints: <old-pvc-name>=<old-pvc-name>
+```
+
+## Root Cause
+
+The operator does not reconcile the cast-runtime Deployment's PVC reference against the
+DataSource `pvc-name` annotation after a DataSource delete-and-recreate. The stale reference
+persists in the Deployment until manually patched.
+
+## When to Apply
+
+**After the schema-init requeue loop ([W005](W005-schema-init-ttl-requeue-loop.md)) is
+resolved** and the cast-runtime pod is still `Pending` with a PVC mismatch confirmed. Both
+issues must be addressed for the cast-runtime pod to reach `Running`.
+
+## Steps
+
+```bash
+DOMAIN=$(oc get domain -n ibm-cas -o jsonpath='{.items[0].metadata.name}')
+CAST_DEPLOY=$(oc get deployment -n ibm-cas \
+  -l app.kubernetes.io/component=cast-runtime \
+  -o jsonpath='{.items[0].metadata.name}')
+NEW_PVC=$(oc get datasource -n ibm-cas "${DOMAIN}-datasource" \
+  -o jsonpath='{.metadata.annotations.pvc-name}')
+
+oc patch deployment "${CAST_DEPLOY}" -n ibm-cas --type=json -p="[
+  {\"op\":\"replace\",\"path\":\"/spec/template/spec/volumes/1/name\",\"value\":\"${NEW_PVC}\"},
+  {\"op\":\"replace\",\"path\":\"/spec/template/spec/volumes/1/persistentVolumeClaim/claimName\",\"value\":\"${NEW_PVC}\"},
+  {\"op\":\"replace\",\"path\":\"/spec/template/spec/containers/0/volumeMounts/1/name\",\"value\":\"${NEW_PVC}\"}
+]"
+```
+
+## Verify
+
+```bash
+oc get pod -n ibm-cas -l app.kubernetes.io/component=cast-runtime
+# Expected: Running
+
+oc get datasource -n ibm-cas \
+  -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.status.connectionStatus}{"\n"}{end}'
+# Expected: Connected
+```

--- a/CAS/local-data-caching/jobs/migration.sh
+++ b/CAS/local-data-caching/jobs/migration.sh
@@ -1,0 +1,1298 @@
+#!/bin/bash
+set -euo pipefail
+
+# CAS Data Cache Migration - Job Script
+# Executes inside Kubernetes Job pod with cluster access
+# Performs actual migration operations with database and filesystem access
+
+# ============================================================================
+# 0. INSTALL REQUIRED CLI TOOLS
+# ============================================================================
+
+install_cli_tools() {
+  log "Checking for required CLI tools..."
+
+  # Detect OS/distro once — needed by multiple install blocks below
+  if [[ -f /etc/os-release ]]; then
+    . /etc/os-release
+    OS_ID="${ID}"
+    log "Detected OS: ${OS_ID}"
+  else
+    log_error "Cannot detect OS - /etc/os-release not found"
+    return 1
+  fi
+
+  # kubectl
+  if command -v kubectl &>/dev/null; then
+    log "kubectl already installed: $(kubectl version --client 2>/dev/null | head -1)"
+  else
+    log "Installing kubectl..."
+    case "${OS_ID}" in
+      debian|ubuntu)
+        apt-get update -qq
+        apt-get install -y -qq curl
+        ;;
+      rhel|centos|fedora)
+        microdnf install -y tar gzip
+        ;;
+      *)
+        log_error "Unsupported OS: ${OS_ID}"
+        return 1
+        ;;
+    esac
+    curl -sSLo /tmp/kubectl \
+      "https://dl.k8s.io/release/$(curl -sSL https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+    install -m 755 /tmp/kubectl /usr/local/bin/kubectl
+    rm -f /tmp/kubectl
+    if ! command -v kubectl &>/dev/null; then
+      log_error "kubectl installation failed — binary not found after install"
+      return 1
+    fi
+    log_success "kubectl installed: $(kubectl version --client 2>/dev/null | head -1)"
+  fi
+
+  # psql
+  if command -v psql &>/dev/null; then
+    log "psql already installed: $(psql --version)"
+  else
+    log "Installing postgresql-client..."
+    case "${OS_ID}" in
+      debian|ubuntu)
+        apt-get update -qq
+        apt-get install -y -qq postgresql-client
+        ;;
+      rhel|centos|fedora)
+        microdnf install -y postgresql
+        ;;
+      *)
+        log_error "Unsupported OS: ${OS_ID}"
+        return 1
+        ;;
+    esac
+    if ! command -v psql &>/dev/null; then
+      log_error "psql installation failed — binary not found after install"
+      return 1
+    fi
+    log_success "psql installed: $(psql --version)"
+  fi
+
+  # yq
+  if command -v yq &>/dev/null; then
+    log "yq already installed: $(yq --version 2>/dev/null)"
+  else
+    log "Installing yq..."
+    curl -sSLo /tmp/yq \
+      "https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64"
+    install -m 755 /tmp/yq /usr/local/bin/yq
+    rm -f /tmp/yq
+    if ! command -v yq &>/dev/null; then
+      log_error "yq installation failed — binary not found after install"
+      return 1
+    fi
+    log_success "yq installed: $(yq --version 2>/dev/null)"
+  fi
+
+  log_success "All required CLI tools are available"
+}
+
+# ============================================================================
+# 1. LOGGING AND UTILITIES
+# ============================================================================
+
+# DRY_RUN_JOB mode: echo commands instead of executing
+DRY_RUN_JOB="${DRY_RUN_JOB:-false}"
+
+log() {
+  echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] $*"
+}
+
+log_error() {
+  echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] ERROR: $*" >&2
+}
+
+log_success() {
+  echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] SUCCESS: $*"
+}
+
+# ============================================================================
+# 2. STATE MANAGEMENT FUNCTIONS
+# ============================================================================
+
+update_migration_progress() {
+  local phase="${1}"
+  local status="${2}"
+  local backup_path="${3:-}"
+  
+  log "Updating migration state: ${phase} -> ${status}"
+  
+  # Check if ConfigMap exists, create if not
+  if ! kubectl get configmap cas-migration-state -n "${CAS_NAMESPACE}" &>/dev/null; then
+    log "Creating cas-migration-state ConfigMap..."
+    if ! kubectl create configmap cas-migration-state -n "${CAS_NAMESPACE}" \
+      --from-literal="${phase}-migration-status=${status}" \
+      --from-literal="${phase}-migration-timestamp=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+      --from-literal="${phase}-migration-backup-path=${backup_path}"; then
+      log_error "Failed to create state ConfigMap"
+      return 1
+    fi
+    log_success "State ConfigMap created"
+  else
+    # Update existing ConfigMap
+    if ! kubectl patch configmap cas-migration-state -n "${CAS_NAMESPACE}" \
+      --type merge \
+      -p "{\"data\":{\"${phase}-migration-status\":\"${status}\",\"${phase}-migration-timestamp\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\",\"${phase}-migration-backup-path\":\"${backup_path}\"}}"; then
+      log_error "Failed to update state ConfigMap"
+      return 1
+    fi
+    log_success "State updated successfully"
+  fi
+}
+
+# ============================================================================
+# 3. DATABASE ACCESS
+# ============================================================================
+
+get_database_credentials() {
+  log "Retrieving database credentials from Secret..."
+  
+  # Get database credentials from cluster-parade-app Secret
+  local secret_name="cluster-parade-app"
+  
+  DB_HOST=$(kubectl get secret "${secret_name}" -n "${CAS_NAMESPACE}" \
+    -o jsonpath='{.data.host}' | base64 -d)
+  
+  DB_USER=$(kubectl get secret "${secret_name}" -n "${CAS_NAMESPACE}" \
+    -o jsonpath='{.data.username}' | base64 -d)
+  
+  DB_PASS=$(kubectl get secret "${secret_name}" -n "${CAS_NAMESPACE}" \
+    -o jsonpath='{.data.password}' | base64 -d)
+  
+  DB_NAME=$(kubectl get secret "${secret_name}" -n "${CAS_NAMESPACE}" \
+    -o jsonpath='{.data.dbname}' | base64 -d)
+  
+  export PGPASSWORD="${DB_PASS}"
+  
+  log_success "Database credentials retrieved"
+}
+
+test_database_connection() {
+  log "Testing database connection..."
+  log "  Host: ${DB_HOST}"
+  log "  Port: 5432"
+  log "  Database: ${DB_NAME}"
+  log "  User: ${DB_USER}"
+  
+  # Test with verbose output and timeout
+  if timeout 10 psql -h "${DB_HOST}" -U "${DB_USER}" -d "${DB_NAME}" \
+    -c "SELECT 1" 2>&1; then
+    log_success "Database connection successful"
+    return 0
+  else
+    local exit_code=$?
+    log_error "Database connection failed (exit code: ${exit_code})"
+    
+    # Try to diagnose the issue
+    log "Attempting DNS resolution..."
+    if command -v nslookup &>/dev/null; then
+      nslookup "${DB_HOST}" 2>&1 || true
+    elif command -v dig &>/dev/null; then
+      dig "${DB_HOST}" 2>&1 || true
+    else
+      log "DNS tools not available"
+    fi
+    
+    log "Attempting ping..."
+    if command -v ping &>/dev/null; then
+      timeout 3 ping -c 2 "${DB_HOST}" 2>&1 || true
+    else
+      log "ping not available"
+    fi
+    
+    return 1
+  fi
+}
+
+# ============================================================================
+# 4. PRE-MIGRATION OPERATIONS
+# ============================================================================
+
+# get_s3_cachefs_datasources — prints newline-delimited names of S3 datasources
+# that reference FILESYSTEM_NAME in spec.s3.fileSystemName
+get_s3_cachefs_datasources() {
+  kubectl get datasources -n "${CAS_NAMESPACE}" \
+    -o jsonpath='{range .items[?(@.spec.s3.fileSystemName=="'"${FILESYSTEM_NAME}"'")]}{.metadata.name}{"\n"}{end}' \
+    2>/dev/null
+}
+
+backup_datasources() {
+  local backup_dir="${1}"
+
+  log "Backing up S3+cache-fs DataSources to: ${backup_dir}"
+
+  # Create backup directory
+  mkdir -p "${backup_dir}"
+
+  # Collect S3+cache-fs datasource names
+  local s3_ds_names
+  s3_ds_names=$(get_s3_cachefs_datasources)
+
+  if [[ -z "${s3_ds_names}" ]]; then
+    log "No S3 datasources using filesystem '${FILESYSTEM_NAME}' found — nothing to backup"
+    # Write empty list file so verify_backup_exists still has a file to check
+    echo '{"apiVersion":"v1","kind":"List","items":[]}' > "${backup_dir}/datasources.yaml"
+    return 0
+  fi
+
+  # Backup each S3 datasource CR individually into a combined List yaml
+  {
+    echo "apiVersion: v1"
+    echo "kind: List"
+    echo "items:"
+    while IFS= read -r ds_name; do
+      [[ -z "${ds_name}" ]] && continue
+      kubectl get datasource "${ds_name}" -n "${CAS_NAMESPACE}" -o yaml 2>/dev/null \
+        | yq eval 'del(.spec.disconnect)' - \
+        | sed 's/^/- /' \
+        | sed '2,$s/^- /  /'
+    done <<< "${s3_ds_names}"
+  } > "${backup_dir}/datasources.yaml"
+
+  local ds_count
+  ds_count=$(echo "${s3_ds_names}" | grep -c '[^[:space:]]')
+  log_success "Backed up ${ds_count} S3+cache-fs DataSource(s)"
+
+  # Backup the S3 credentials secrets for each datasource
+  mkdir -p "${backup_dir}/secrets"
+  while IFS= read -r ds_name; do
+    [[ -z "${ds_name}" ]] && continue
+    local secret_name
+    secret_name=$(kubectl get datasource "${ds_name}" -n "${CAS_NAMESPACE}" \
+      -o jsonpath='{.spec.s3.credentials.secretName}' 2>/dev/null)
+    if [[ -z "${secret_name}" ]]; then
+      log "DataSource '${ds_name}' has no spec.s3.credentials.secretName — skipping secret backup"
+      continue
+    fi
+    log "Backing up secret '${secret_name}' for DataSource '${ds_name}'"
+    if ! kubectl get secret "${secret_name}" -n "${CAS_NAMESPACE}" -o yaml \
+      > "${backup_dir}/secrets/${ds_name}-credentials.yaml"; then
+      log_error "Failed to backup secret '${secret_name}' for DataSource '${ds_name}'"
+      return 1
+    fi
+  done <<< "${s3_ds_names}"
+  log_success "S3 credentials secrets backed up"
+
+  # Disconnect each S3+cache-fs DataSource so the Scale watch is torn down
+  # Note: do NOT delete PVC/Kafka topic/AFM fileset yet — Document Processor needs
+  # them to drain. The datasource is disconnected but not deleted here.
+  while IFS= read -r ds_name; do
+    [[ -z "${ds_name}" ]] && continue
+    log "Patching DataSource '${ds_name}' with spec.disconnect=true"
+    if [[ "${DRY_RUN_JOB}" == "true" ]]; then
+      log "[DRY-RUN] Would execute: kubectl patch datasource '${ds_name}' -n '${CAS_NAMESPACE}' --type=merge -p '{\"spec\":{\"disconnect\":true}}'"
+      continue
+    fi
+    kubectl patch datasource "${ds_name}" -n "${CAS_NAMESPACE}" \
+      --type=merge -p '{"spec":{"disconnect":true}}' || {
+      log_error "Failed to patch DataSource '${ds_name}' with disconnect=true"
+      return 1
+    }
+  done <<< "${s3_ds_names}"
+  log_success "All S3+cache-fs DataSources disconnected"
+}
+
+# wait_for_kafka_lag_zero — waits until the Kafka consumer lag for every
+# S3+cache-fs datasource's child topic reaches 0 (or timeout expires).
+#
+# Uses kafka-consumer-groups.sh inside the Strimzi Kafka pod to query lag.
+# The child topic name is taken from the datasource's fsnotify-topic annotation.
+# The consumer group is derived as "<fsnotify-topic>" (the group registered by
+# the DocumentProcessor consumer for that topic).
+wait_for_kafka_lag_zero() {
+  local timeout_seconds="${KAFKA_DRAIN_TIMEOUT:-600}"
+  local poll_interval=10
+
+  log "=== Waiting for Kafka consumer lag to drain ==="
+  log "Timeout: ${timeout_seconds}s  Poll interval: ${poll_interval}s"
+
+  # Locate the Strimzi Kafka pod (label: strimzi.io/kind=Kafka)
+  local kafka_pod
+  kafka_pod=$(kubectl get pods -n "${CAS_NAMESPACE}" \
+    -l "strimzi.io/kind=Kafka" \
+    --no-headers -o custom-columns=NAME:.metadata.name 2>/dev/null | head -n1)
+
+  if [[ -z "${kafka_pod}" ]]; then
+    log "No Strimzi Kafka pod found in namespace '${CAS_NAMESPACE}' — skipping Kafka lag check"
+    return 0
+  fi
+  log "Using Kafka pod: ${kafka_pod}"
+
+  # Collect per-datasource (topic, group) pairs
+  local s3_ds_names
+  s3_ds_names=$(get_s3_cachefs_datasources)
+
+  if [[ -z "${s3_ds_names}" ]]; then
+    log "No S3+cache-fs datasources — skipping Kafka lag check"
+    return 0
+  fi
+
+  local elapsed=0
+  while [[ ${elapsed} -lt ${timeout_seconds} ]]; do
+    local all_zero=true
+
+    while IFS= read -r ds_name; do
+      [[ -z "${ds_name}" ]] && continue
+
+      local topic
+      topic=$(kubectl get datasource "${ds_name}" -n "${CAS_NAMESPACE}" \
+        -o jsonpath='{.metadata.annotations.fsnotify-topic}' 2>/dev/null)
+
+      if [[ -z "${topic}" ]]; then
+        log "DataSource '${ds_name}' has no fsnotify-topic annotation — skipping"
+        continue
+      fi
+
+      # Query lag for this topic across all consumer groups
+      local lag_output
+      lag_output=$(kubectl exec -n "${CAS_NAMESPACE}" "${kafka_pod}" \
+        -c kafka -- \
+        bin/kafka-consumer-groups.sh \
+          --bootstrap-server localhost:9092 \
+          --describe --all-groups \
+          2>/dev/null | grep "^${topic}\b\|${topic}$\| ${topic} ")
+
+      # Sum the LAG column (column 5 in the output: GROUP TOPIC PARTITION CURRENT-OFFSET LOG-END-OFFSET LAG ...)
+      local total_lag=0
+      while IFS= read -r line; do
+        [[ -z "${line}" ]] && continue
+        local lag_val
+        lag_val=$(echo "${line}" | awk '{print $6}' | grep -E '^[0-9]+$' || echo "0")
+        total_lag=$(( total_lag + ${lag_val:-0} ))
+      done <<< "${lag_output}"
+
+      log "  DataSource '${ds_name}' topic '${topic}': lag=${total_lag}"
+
+      if [[ ${total_lag} -gt 0 ]]; then
+        all_zero=false
+      fi
+    done <<< "${s3_ds_names}"
+
+    if [[ "${all_zero}" == "true" ]]; then
+      log_success "Kafka consumer lag reached 0 for all S3+cache-fs datasource topics"
+      return 0
+    fi
+
+    log "Kafka lag not yet 0 — waiting ${poll_interval}s (elapsed: ${elapsed}s / ${timeout_seconds}s)"
+    sleep "${poll_interval}"
+    elapsed=$(( elapsed + poll_interval ))
+  done
+
+  log_error "Kafka consumer lag did not reach 0 within ${timeout_seconds}s"
+  return 1
+}
+
+# wait_for_task_queue_zero — waits until the Document Processor task queue
+# depth reaches 0, queried from the cast-runtime pod's /metrics endpoint.
+#
+# Metric: cast_task_queue_depth (gauge exposed by cast-runtime container)
+# Label:  dp_name=<documentprocessor-name>
+wait_for_task_queue_zero() {
+  local timeout_seconds="${TASK_QUEUE_DRAIN_TIMEOUT:-600}"
+  local poll_interval=10
+
+  log "=== Waiting for Document Processor task queues to drain ==="
+  log "Timeout: ${timeout_seconds}s  Poll interval: ${poll_interval}s"
+
+  # Discover DocumentProcessors that reference S3+cache-fs datasources
+  local s3_ds_names
+  s3_ds_names=$(get_s3_cachefs_datasources)
+
+  if [[ -z "${s3_ds_names}" ]]; then
+    log "No S3+cache-fs datasources — skipping task queue drain check"
+    return 0
+  fi
+
+  # Build set of DocumentProcessor names associated with affected datasources
+  local dp_names=""
+  while IFS= read -r ds_name; do
+    [[ -z "${ds_name}" ]] && continue
+    # Find DPs whose domain references this datasource
+    local dp_list
+    dp_list=$(kubectl get documentprocessors -n "${CAS_NAMESPACE}" \
+      --no-headers -o custom-columns=NAME:.metadata.name 2>/dev/null)
+    while IFS= read -r dp_name; do
+      [[ -z "${dp_name}" ]] && continue
+      # Check if any domain associated with this DP references our datasource
+      local dp_domains
+      dp_domains=$(kubectl get documentprocessor "${dp_name}" -n "${CAS_NAMESPACE}" \
+        -o jsonpath='{.spec.domains[*]}' 2>/dev/null | tr ' ' '\n')
+      while IFS= read -r domain_name; do
+        [[ -z "${domain_name}" ]] && continue
+        local domain_ds
+        domain_ds=$(kubectl get domain "${domain_name}" -n "${CAS_NAMESPACE}" \
+          -o jsonpath='{.spec.dataSources[*]}' 2>/dev/null | tr ' ' '\n')
+        if echo "${domain_ds}" | grep -qx "${ds_name}"; then
+          if ! echo "${dp_names}" | grep -qx "${dp_name}"; then
+            dp_names="${dp_names:+${dp_names}$'\n'}${dp_name}"
+          fi
+        fi
+      done <<< "${dp_domains}"
+    done <<< "${dp_list}"
+  done <<< "${s3_ds_names}"
+
+  if [[ -z "${dp_names}" ]]; then
+    log "No DocumentProcessors found for S3+cache-fs datasources — skipping task queue check"
+    return 0
+  fi
+
+  local elapsed=0
+  while [[ ${elapsed} -lt ${timeout_seconds} ]]; do
+    local all_zero=true
+
+    while IFS= read -r dp_name; do
+      [[ -z "${dp_name}" ]] && continue
+
+      # Find the running cast-runtime pod for this DP
+      local dp_pod
+      dp_pod=$(kubectl get pods -n "${CAS_NAMESPACE}" \
+        -l "app.kubernetes.io/component=cast-runtime,app.kubernetes.io/part-of=${dp_name}" \
+        --no-headers -o custom-columns=NAME:.metadata.name,STATUS:.status.phase 2>/dev/null \
+        | awk '$2=="Running"{print $1}' | head -n1)
+
+      if [[ -z "${dp_pod}" ]]; then
+        log "  DocumentProcessor '${dp_name}': no running pod found — treating queue as 0"
+        continue
+      fi
+
+      # Scrape the cast_task_queue_depth metric from the pod's /metrics endpoint
+      local queue_depth=0
+      local metrics_raw
+      metrics_raw=$(kubectl exec -n "${CAS_NAMESPACE}" "${dp_pod}" \
+        -- curl -sSf http://localhost:8080/metrics 2>/dev/null \
+        || kubectl exec -n "${CAS_NAMESPACE}" "${dp_pod}" \
+           -- curl -sSf http://localhost:9090/metrics 2>/dev/null \
+        || echo "")
+
+      if [[ -n "${metrics_raw}" ]]; then
+        # Sum all cast_task_queue_depth values (may have multiple label combos)
+        queue_depth=$(echo "${metrics_raw}" \
+          | grep '^cast_task_queue_depth' \
+          | awk '{sum += $NF} END {print int(sum+0)}')
+        queue_depth="${queue_depth:-0}"
+      else
+        log "  DocumentProcessor '${dp_name}' pod '${dp_pod}': could not scrape metrics — treating queue as 0"
+      fi
+
+      log "  DocumentProcessor '${dp_name}' task queue depth: ${queue_depth}"
+
+      if [[ "${queue_depth}" -gt 0 ]]; then
+        all_zero=false
+      fi
+    done <<< "${dp_names}"
+
+    if [[ "${all_zero}" == "true" ]]; then
+      log_success "All Document Processor task queues drained to 0"
+      return 0
+    fi
+
+    log "Task queues not yet empty — waiting ${poll_interval}s (elapsed: ${elapsed}s / ${timeout_seconds}s)"
+    sleep "${poll_interval}"
+    elapsed=$(( elapsed + poll_interval ))
+  done
+
+  log_error "Document Processor task queues did not drain within ${timeout_seconds}s"
+  return 1
+}
+
+# delete_document_processors — scales the CAS operator to 0, deletes every
+# DocumentProcessor CR (removing any blocking finalizers), waits for them to
+# be fully gone, then scales the operator back up.
+delete_document_processors() {
+  local operator_deploy="ibm-isf-cas-operator-controller-manager"
+  local timeout_seconds="${DP_DELETE_TIMEOUT:-300}"
+  local poll_interval=5
+
+  log "=== Deleting DocumentProcessors via operator scale-down ==="
+
+  # Collect all DocumentProcessor names up front
+  local dp_names
+  dp_names=$(kubectl get documentprocessors -n "${CAS_NAMESPACE}" \
+    --no-headers -o custom-columns=NAME:.metadata.name 2>/dev/null)
+
+  if [[ -z "${dp_names}" ]]; then
+    log "No DocumentProcessors found — nothing to delete"
+    return 0
+  fi
+
+  # Step 1: Scale the CAS operator to 0 and wait for its pod to terminate.
+  # NOTE: the CLI launcher (migrate-data-cache.sh) labels the CSV olm.managed=false
+  # before launching this job, so OLM will not fight the scale-down.
+  log "Scaling CAS operator '${operator_deploy}' to 0"
+  if [[ "${DRY_RUN_JOB}" == "true" ]]; then
+    log "[DRY-RUN] Would execute: kubectl scale deployment '${operator_deploy}' -n '${CAS_NAMESPACE}' --replicas=0"
+    log "[DRY-RUN] Would execute: kubectl wait pod -n '${CAS_NAMESPACE}' -l control-plane=controller-manager --for=delete --timeout=120s"
+  else
+    kubectl scale deployment "${operator_deploy}" -n "${CAS_NAMESPACE}" --replicas=0 || {
+      log_error "Failed to scale down CAS operator '${operator_deploy}'"
+      return 1
+    }
+    log "Waiting for CAS operator pod to terminate..."
+    kubectl wait pod -n "${CAS_NAMESPACE}" \
+      -l "control-plane=controller-manager" \
+      --for=delete --timeout=120s 2>/dev/null || true
+    log "CAS operator pod gone"
+  fi
+
+  # Step 2: Delete first; if the object gets stuck on finalizers (operator is
+  # scaled to 0 and cannot process them), strip them so the delete completes.
+  # --wait=false avoids blocking on the API server's delete confirmation.
+  while IFS= read -r dp_name; do
+    [[ -z "${dp_name}" ]] && continue
+    log "Deleting DocumentProcessor '${dp_name}'"
+    if [[ "${DRY_RUN_JOB}" == "true" ]]; then
+      log "[DRY-RUN] Would execute: kubectl delete documentprocessor '${dp_name}' -n '${CAS_NAMESPACE}' --ignore-not-found --wait=false"
+      log "[DRY-RUN] Would execute: kubectl patch documentprocessor '${dp_name}' -n '${CAS_NAMESPACE}' --type=merge -p '{\"metadata\":{\"finalizers\":[]}}'"
+      continue
+    fi
+    kubectl delete documentprocessor "${dp_name}" -n "${CAS_NAMESPACE}" --ignore-not-found --wait=false || {
+      log_error "Failed to delete DocumentProcessor '${dp_name}'"
+      return 1
+    }
+    # Strip finalizers so the object is not stuck waiting for operator
+    # reconciliation (operator is scaled to 0 at this point)
+    kubectl patch documentprocessor "${dp_name}" -n "${CAS_NAMESPACE}" \
+      --type=merge -p '{"metadata":{"finalizers":[]}}' 2>/dev/null || true
+  done <<< "${dp_names}"
+
+  # Step 3: Wait for all DocumentProcessors to be gone
+  if [[ "${DRY_RUN_JOB}" != "true" ]]; then
+    log "Waiting for DocumentProcessors to be fully deleted (timeout: ${timeout_seconds}s)"
+    local elapsed=0
+    while [[ ${elapsed} -lt ${timeout_seconds} ]]; do
+      local remaining
+      remaining=$(kubectl get documentprocessors -n "${CAS_NAMESPACE}" \
+        --no-headers 2>/dev/null | grep -v '^$' | wc -l)
+      if [[ "${remaining}" -eq 0 ]]; then
+        log_success "All DocumentProcessors deleted"
+        break
+      fi
+      log "  ${remaining} DocumentProcessor(s) still present — waiting ${poll_interval}s (elapsed: ${elapsed}s / ${timeout_seconds}s)"
+      sleep "${poll_interval}"
+      elapsed=$(( elapsed + poll_interval ))
+    done
+    if [[ ${elapsed} -ge ${timeout_seconds} ]]; then
+      log_error "DocumentProcessors did not finish deleting within ${timeout_seconds}s"
+      return 1
+    fi
+  fi
+
+  # Operator is intentionally left at 0 replicas here.
+  # perform_pre_migration() scales it back up only after delete_s3_datasources()
+  # completes, so the operator cannot pick up the DP Terminating event and drop
+  # the ParadeDB tables before we are done.
+}
+
+scale_up_cas_operator() {
+  local operator_deploy="ibm-isf-cas-operator-controller-manager"
+  # NOTE: the CLI launcher (migrate-data-cache.sh) restores the olm.managed label
+  # after the job completes. No CSV label manipulation is done here.
+  log "Scaling CAS operator '${operator_deploy}' back to 1"
+  if [[ "${DRY_RUN_JOB}" == "true" ]]; then
+    log "[DRY-RUN] Would execute: kubectl scale deployment '${operator_deploy}' -n '${CAS_NAMESPACE}' --replicas=1"
+  else
+    kubectl scale deployment "${operator_deploy}" -n "${CAS_NAMESPACE}" --replicas=1 || {
+      log_error "Failed to scale CAS operator '${operator_deploy}' back up"
+      return 1
+    }
+  fi
+  log_success "CAS operator scaled back to 1"
+}
+
+# delete_s3_datasources — deletes each S3+cache-fs datasource after backup.
+# Before each delete, reads the watch-id annotation and disables the mmwatch
+# on the Scale filesystem — the operator will not clean this up once the
+# DataSource CR is gone.
+delete_s3_datasources() {
+  local s3_ds_names
+  s3_ds_names=$(get_s3_cachefs_datasources)
+
+  if [[ -z "${s3_ds_names}" ]]; then
+    log "No S3+cache-fs datasources to delete"
+    return 0
+  fi
+
+  log "=== Deleting S3+cache-fs DataSources ==="
+
+  # Locate the Scale core pod once — reused for every mmwatch disable call
+  local core_pod
+  core_pod=$(kubectl get pod -n "${SCALE_NAMESPACE}" \
+    -l "app.kubernetes.io/instance=ibm-spectrum-scale,app.kubernetes.io/name=core" \
+    --no-headers -o custom-columns=NAME:.metadata.name 2>/dev/null | head -n1)
+
+  while IFS= read -r ds_name; do
+    [[ -z "${ds_name}" ]] && continue
+    log "Deleting DataSource '${ds_name}'"
+    if [[ "${DRY_RUN_JOB}" == "true" ]]; then
+      log "[DRY-RUN] Would execute: mmwatch ${FILESYSTEM_NAME} disable --watch-id <watch-id>"
+      log "[DRY-RUN] Would execute: kubectl delete datasource '${ds_name}' -n '${CAS_NAMESPACE}'"
+      continue
+    fi
+    # Disable the Scale mmwatch before deleting so no orphaned watch is left behind
+    local watch_id
+    watch_id=$(kubectl get datasource "${ds_name}" -n "${CAS_NAMESPACE}" \
+      -o jsonpath='{.metadata.annotations.watch-id}' 2>/dev/null)
+    if [[ -n "${watch_id}" && -n "${core_pod}" ]]; then
+      log "  Disabling mmwatch watch-id '${watch_id}' for DataSource '${ds_name}'"
+      kubectl exec -n "${SCALE_NAMESPACE}" "${core_pod}" -- \
+        mmwatch "${FILESYSTEM_NAME}" disable --watch-id "${watch_id}" 2>&1 || true
+    else
+      log "  No watch-id annotation on '${ds_name}' — skipping mmwatch disable"
+    fi
+    kubectl delete datasource "${ds_name}" -n "${CAS_NAMESPACE}" || {
+      log_error "Failed to delete DataSource '${ds_name}'"
+      return 1
+    }
+  done <<< "${s3_ds_names}"
+
+  log_success "All S3+cache-fs DataSources deleted"
+}
+
+backup_document_processors() {
+  local backup_dir="${1}"
+
+  log "Backing up DocumentProcessors..."
+
+  {
+    echo "apiVersion: v1"
+    echo "kind: List"
+    echo "items:"
+    kubectl get documentprocessors -n "${CAS_NAMESPACE}" -o yaml 2>/dev/null \
+      | yq eval '.items[]' - \
+      | sed 's/^/- /' \
+      | sed '2,$s/^- /  /'
+  } > "${backup_dir}/documentprocessors.yaml"
+
+  local count
+  count=$(yq eval '.items | length' "${backup_dir}/documentprocessors.yaml" 2>/dev/null || echo 0)
+  log_success "Backed up ${count} DocumentProcessor(s)"
+}
+
+backup_configmaps() {
+  local backup_dir="${1}"
+  
+  log "Backing up CAS ConfigMaps..."
+  
+  if kubectl get configmaps -n "${CAS_NAMESPACE}" \
+    -l "app.kubernetes.io/name=cas" \
+    -o yaml > "${backup_dir}/configmaps.yaml"; then
+    log_success "ConfigMaps backed up"
+  else
+    log_error "Failed to backup ConfigMaps"
+    return 1
+  fi
+}
+
+create_backup_metadata() {
+  local backup_dir="${1}"
+  
+  log "Creating backup metadata..."
+  
+  cat > "${backup_dir}/metadata.json" <<EOF
+{
+  "timestamp": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+  "filesystem": "${FILESYSTEM_NAME}",
+  "namespace": "${CAS_NAMESPACE}",
+  "migration_marker": "cas_migration_${MIGRATION_TIMESTAMP}",
+  "phase": "pre-migration",
+  "job_name": "${JOB_NAME:-unknown}"
+}
+EOF
+  
+  log_success "Metadata created"
+}
+
+perform_pre_migration() {
+  local backup_dir="/mnt/${MIGRATION_PVC_NAME}/migration-backup/${MIGRATION_TIMESTAMP}"
+
+  log "=== Starting Pre-Migration ==="
+  log "Backup directory: ${backup_dir}"
+
+  # Create backup directory
+  mkdir -p "${backup_dir}" || {
+    log_error "Failed to create backup directory"
+    return 1
+  }
+
+  # i. Save S3+cache-fs datasource yaml and secret yaml(s), then disconnect each datasource
+  backup_datasources "${backup_dir}" || return 1
+
+  # ii.a. Wait for Kafka consumer lag to reach 0 for each affected topic
+  wait_for_kafka_lag_zero || return 1
+
+  # ii.b. Wait for Document Processor task queues to reach 0
+  wait_for_task_queue_zero || return 1
+
+  # iii. Backup DocumentProcessors now that queues are drained
+  backup_document_processors "${backup_dir}" || return 1
+
+  # iv. Create metadata
+  create_backup_metadata "${backup_dir}" || return 1
+
+  # v. Delete DocumentProcessors (operator scaled to 0 inside)
+  delete_document_processors || return 1
+
+  # vi. Scale operator back up now that all DP CRs are gone — safe because there
+  #     are no admission webhooks for DataSources that would re-trigger DP deletion
+  scale_up_cas_operator || return 1
+
+  # vii. Delete S3 datasources (operator is running; webhooks for DS are present
+  #      but DP tables are already preserved since no DP CRs remain to reconcile)
+  delete_s3_datasources || return 1
+
+  # Update state
+  update_migration_progress "pre" "completed" "${backup_dir}" || return 1
+
+  log_success "=== Pre-Migration Complete ==="
+  log "Backup location: ${backup_dir}"
+}
+
+# ============================================================================
+# 5. BACKUP OPERATIONS
+# ============================================================================
+
+verify_backup_exists() {
+  local backup_dir="${1}"
+  
+  log "Verifying backup directory: ${backup_dir}"
+  
+  if [[ ! -d "${backup_dir}" ]]; then
+    log_error "Backup directory not found: ${backup_dir}"
+    log_error "Pre-migration must be run first"
+    return 1
+  fi
+  
+  # Check for required backup files
+  for file in datasources.yaml documentprocessors.yaml metadata.json; do
+    if [[ ! -f "${backup_dir}/${file}" ]]; then
+      log_error "Required backup file missing: ${file}"
+      return 1
+    fi
+  done
+  
+  log_success "Backup verification complete"
+  log "  Location: ${backup_dir}"
+  log "  Files: datasources.yaml documentprocessors.yaml metadata.json"
+  
+  return 0
+}
+
+find_latest_backup() {
+  local backup_base_dir="/mnt/${MIGRATION_PVC_NAME}/migration-backup"
+  
+  log "Searching for latest backup in: ${backup_base_dir}" >&2
+  
+  if [[ ! -d "${backup_base_dir}" ]]; then
+    log_error "Backup base directory not found: ${backup_base_dir}"
+    return 1
+  fi
+  
+  # Find most recent backup directory
+  local latest_backup
+  latest_backup=$(find "${backup_base_dir}" -maxdepth 1 -type d -name "20*" | sort -r | head -n1)
+  
+  if [[ -z "${latest_backup}" ]]; then
+    log_error "No backup found in ${backup_base_dir}"
+    return 1
+  fi
+  
+  log_success "Found backup: ${latest_backup}" >&2
+  echo "${latest_backup}"
+}
+
+# ============================================================================
+# 6. DATABASE OPERATIONS
+# ============================================================================
+
+check_database_migration_applied() {
+  local migration_marker="cas_migration_${MIGRATION_TIMESTAMP}"
+  
+  log "Checking if database migration already applied..."
+  log "Migration marker: ${migration_marker}"
+  
+  # In dry-run mode, skip all database checks
+  if [[ "${DRY_RUN_JOB}" == "true" ]]; then
+    log "[DRY-RUN] Would check if migration_log table exists"
+    log "[DRY-RUN] Would check for migration marker: ${migration_marker}"
+    log "[DRY-RUN] Assuming migration not yet applied"
+    return 1
+  fi
+  
+  # Check if migration_log table exists
+  local table_exists
+  table_exists=$(psql -h "${DB_HOST}" -U "${DB_USER}" -d "${DB_NAME}" \
+    -tAc "SELECT EXISTS (SELECT FROM information_schema.tables WHERE table_name = 'migration_log')" 2>/dev/null || echo "f")
+  
+  if [[ "${table_exists}" == "f" ]]; then
+    log "Migration log table does not exist, creating..."
+    
+    local create_table_sql
+    create_table_sql=$(cat <<EOF
+CREATE TABLE IF NOT EXISTS migration_log (
+  id SERIAL PRIMARY KEY,
+  marker VARCHAR(255) UNIQUE NOT NULL,
+  timestamp TIMESTAMP NOT NULL,
+  phase VARCHAR(50) NOT NULL,
+  old_path TEXT,
+  new_path TEXT
+);
+EOF
+)
+    
+    if [[ "${DRY_RUN_JOB}" == "true" ]]; then
+      log "[DRY-RUN] Would execute: psql -h ${DB_HOST} -U ${DB_USER} -d ${DB_NAME} <<EOF"
+      echo "${create_table_sql}"
+      log "[DRY-RUN] EOF"
+      return 1
+    fi
+    
+    psql -h "${DB_HOST}" -U "${DB_USER}" -d "${DB_NAME}" <<EOF
+${create_table_sql}
+EOF
+    return 1  # Not applied yet
+  fi
+  
+  # Check for migration marker
+  local already_migrated
+  already_migrated=$(psql -h "${DB_HOST}" -U "${DB_USER}" -d "${DB_NAME}" \
+    -tAc "SELECT EXISTS(SELECT 1 FROM migration_log WHERE marker='${migration_marker}')" 2>/dev/null || echo "f")
+  
+  if [[ "${already_migrated}" == "t" ]]; then
+    log "Migration marker found - migration already applied"
+    return 0
+  else
+    log "Migration marker not found - migration not yet applied"
+    return 1
+  fi
+}
+
+# update_file_table_inodes BACKUP_DIR
+#
+# After the new cache-fs is created, the operator runs an initial-load scan that
+# inserts a new row into each <domain>_file table for every file it discovers.
+# This new row carries the new inode (file_id) and new pvc_path for the file on
+# the new filesystem.  The pre-migration row for the same file — which has the
+# old inode, old pvc_path, and status=completed plus all its processed embeddings
+# — is still in the table.  We must update the pre-migration row with the new
+# inode/pvc_path/path_id values so the operator's deduplication logic resolves
+# correctly, then remove the now-redundant initial-load row.
+#
+# Strategy: for each <domain>_file table, find pairs of rows that share the same
+# source_path but differ in pvc_path (old fileset vs new fileset).  For each
+# pair, copy file_id, pvc_path, and path_id from the new row onto the old row,
+# then delete the new row.  Rows with no matching new counterpart are left alone.
+update_file_table_inodes() {
+  local backup_dir="${1}"
+  local migration_marker="cas_migration_${MIGRATION_TIMESTAMP}"
+
+  log "=== Database Inode Update ==="
+
+  # Check if migration already applied
+  if check_database_migration_applied; then
+    log "WARN: Database migration already applied (marker: ${migration_marker})"
+    log "WARN: Skipping database updates to maintain idempotency"
+    return 0
+  fi
+
+  # Derive domain names from the DocumentProcessor backup — each DP name maps
+  # directly to a <domain>_file table in ParadeDB.
+  local domains
+  domains=$(yq eval '.items[].metadata.name' "${backup_dir}/documentprocessors.yaml" 2>/dev/null || true)
+
+  if [[ -z "${domains}" ]]; then
+    log "No DocumentProcessors in backup — skipping inode update"
+    return 0
+  fi
+
+  if [[ "${DRY_RUN_JOB}" == "true" ]]; then
+    log "[DRY-RUN] Would update _file table inodes for domains: ${domains}"
+    log "[DRY-RUN] Would record migration marker: ${migration_marker}"
+    log_success "[DRY-RUN] Database inode update skipped (dry-run)"
+    return 0
+  fi
+
+  local any_updated=false
+
+  while IFS= read -r domain; do
+    [[ -z "${domain}" ]] && continue
+    local table="\"${domain}_file\""
+    log "Processing table: ${table}"
+
+    # Check the table exists
+    local table_exists
+    table_exists=$(psql -h "${DB_HOST}" -U "${DB_USER}" -d "${DB_NAME}" \
+      -tAc "SELECT EXISTS (SELECT FROM information_schema.tables WHERE table_name = '${domain}_file')" \
+      2>/dev/null || echo "f")
+
+    if [[ "${table_exists}" != "t" ]]; then
+      log "Table ${table} does not exist — skipping"
+      continue
+    fi
+
+    # Count duplicate source_path pairs (old completed row + new empty-status row)
+    local pair_count
+    pair_count=$(psql -h "${DB_HOST}" -U "${DB_USER}" -d "${DB_NAME}" -tAc "
+      SELECT COUNT(*)
+      FROM ${table} AS old_row
+      JOIN ${table} AS new_row USING (source_path)
+      WHERE old_row.pvc_path <> new_row.pvc_path
+        AND old_row.status = 'completed'
+        AND (new_row.status IS NULL OR new_row.status = '')
+    " 2>/dev/null || echo 0)
+
+    if [[ "${pair_count}" -eq 0 ]]; then
+      log "No stale inode pairs found in ${table} — skipping"
+      continue
+    fi
+
+    log "Found ${pair_count} stale inode pair(s) in ${table} — applying update"
+
+    psql -h "${DB_HOST}" -U "${DB_USER}" -d "${DB_NAME}" <<EOSQL
+BEGIN;
+
+-- Step 1: capture the mapping of old pk -> new values into a temp table.
+-- This avoids unique-constraint violations when the UPDATE and DELETE run
+-- against the same table in the same statement.
+CREATE TEMP TABLE _inode_update_${domain} AS
+SELECT
+  old_row.pk        AS old_pk,
+  new_row.pk        AS new_pk,
+  new_row.file_id   AS new_file_id,
+  new_row.pvc_path  AS new_pvc_path,
+  new_row.path_id   AS new_path_id
+FROM ${table} AS old_row
+JOIN ${table} AS new_row USING (source_path)
+WHERE old_row.pvc_path <> new_row.pvc_path
+  AND old_row.status    = 'completed'
+  AND (new_row.status IS NULL OR new_row.status = '');
+
+-- Step 2: delete the new (initial-load) row first to release the unique
+-- constraint on file_id before the UPDATE tries to assign that value.
+DELETE FROM ${table}
+WHERE pk IN (SELECT new_pk FROM _inode_update_${domain});
+
+-- Step 3: update the old (completed) row with the new inode values.
+UPDATE ${table}
+SET
+  file_id     = u.new_file_id,
+  pvc_path    = u.new_pvc_path,
+  path_id     = u.new_path_id,
+  row_updated = NOW()
+FROM _inode_update_${domain} u
+WHERE pk = u.old_pk;
+
+COMMIT;
+EOSQL
+
+    log_success "Inode update applied for ${table}"
+    any_updated=true
+  done <<< "${domains}"
+
+  # Record migration marker
+  psql -h "${DB_HOST}" -U "${DB_USER}" -d "${DB_NAME}" <<EOSQL
+INSERT INTO migration_log (marker, timestamp, phase, old_path, new_path)
+VALUES ('${migration_marker}', NOW(), 'post-migration', '', '')
+ON CONFLICT (marker) DO NOTHING;
+EOSQL
+
+  if [[ "${any_updated}" == "true" ]]; then
+    log_success "Database inode update complete"
+  else
+    log "No inode pairs required updating across all tables"
+  fi
+  log "Migration marker recorded: ${migration_marker}"
+}
+
+# ============================================================================
+# 7. POST-MIGRATION OPERATIONS
+# ============================================================================
+
+count_datasources_in_backup() {
+  local backup_file="${1}"
+  
+  if [[ ! -f "${backup_file}" ]]; then
+    echo "0"
+    return 0
+  fi
+  
+  # The backup is an 'apiVersion: v1 / kind: List' document.
+  # Items are indented; count by matching the per-item apiVersion line.
+  local count
+  count=$(grep -c "apiVersion: cas.isf.ibm.com/v1beta1" "${backup_file}" 2>/dev/null || true)
+  
+  if [[ -z "${count}" ]]; then
+    count="0"
+  fi
+  
+  echo "${count}"
+}
+
+count_datasources_in_cluster() {
+  local namespace="${1}"
+  
+  # Count DataSource CRs in the cluster
+  local count
+  count=$(kubectl get datasources -n "${namespace}" --no-headers 2>/dev/null | wc -l || true)
+  
+  # If empty, default to 0
+  if [[ -z "${count}" ]]; then
+    count="0"
+  fi
+  
+  # Trim whitespace
+  count=$(echo "${count}" | tr -d '[:space:]')
+  
+  echo "${count}"
+}
+
+restore_datasources() {
+  local backup_dir="${1}"
+  local backup_file="${backup_dir}/datasources.yaml"
+  local clean_file="${backup_dir}/datasources-clean.yaml"
+  
+  log "Restoring DataSources from: ${backup_dir}"
+  
+  # Count DataSources in backup
+  local backup_count
+  backup_count=$(count_datasources_in_backup "${backup_file}")
+  log "DataSources in backup: ${backup_count}"
+  
+  if [[ "${backup_count}" -eq 0 ]]; then
+    log "No DataSources to restore (backup is empty)"
+    return 0
+  fi
+  
+  if [[ "${DRY_RUN_JOB}" == "true" ]]; then
+    log "[DRY-RUN] Would strip server fields and execute: kubectl apply -f ${clean_file}"
+    log_success "[DRY-RUN] ${backup_count} DataSource(s) would be restored"
+    return 0
+  fi
+  
+  # Strip server-managed fields and all operator-written annotations.
+  # The operator re-derives fileset, watch, pvc, and connection annotations
+  # on first reconcile — restoring stale values causes the operator to
+  # skip re-provisioning and leaves the DataSource pointing at the old fileset.
+  log "Stripping server-managed fields and operator annotations from backup..."
+  yq eval '
+    del(.items[].metadata.resourceVersion) |
+    del(.items[].metadata.uid) |
+    del(.items[].metadata.creationTimestamp) |
+    del(.items[].metadata.selfLink) |
+    del(.items[].metadata.generation) |
+    del(.items[].metadata.managedFields) |
+    del(.items[].metadata.finalizers) |
+    del(.items[].metadata.annotations["kubectl.kubernetes.io/last-applied-configuration"]) |
+    del(.items[].metadata.annotations["fileset-path"]) |
+    del(.items[].metadata.annotations["fileset-name"]) |
+    del(.items[].metadata.annotations["fileset-id"]) |
+    del(.items[].metadata.annotations["fsnotify-topic"]) |
+    del(.items[].metadata.annotations["pvc-name"]) |
+    del(.items[].metadata.annotations["pv-name"]) |
+    del(.items[].metadata.annotations["watch-id"]) |
+    del(.items[].metadata.annotations["watch-parent-id"]) |
+    del(.items[].metadata.annotations["connection-status"]) |
+    del(.items[].metadata.annotations["cluster-id"]) |
+    del(.items[].metadata.annotations["cluster-name"]) |
+    del(.items[].metadata.annotations["filesystem-name"]) |
+    del(.items[].metadata.annotations["filesystem-uuid"]) |
+    del(.items[].metadata.annotations["num-retried"]) |
+    del(.items[].status)
+  ' "${backup_file}" > "${clean_file}"
+
+  if ! kubectl apply -f "${clean_file}"; then
+    log_error "Failed to restore DataSources"
+    return 1
+  fi
+  
+  log_success "DataSources restored"
+}
+
+validate_datasource_count() {
+  local backup_dir="${1}"
+  local namespace="${2}"
+  
+  log "Validating DataSource count..."
+  
+  # Count in backup
+  local backup_count
+  backup_count=$(count_datasources_in_backup "${backup_dir}/datasources.yaml")
+  
+  # Count in cluster
+  local cluster_count
+  cluster_count=$(count_datasources_in_cluster "${namespace}")
+  
+  log "  Backup count: ${backup_count}"
+  log "  Cluster count: ${cluster_count}"
+  
+  if [[ "${backup_count}" -eq "${cluster_count}" ]]; then
+    log_success "DataSource count matches (${cluster_count}/${backup_count})"
+    return 0
+  else
+    log_error "DataSource count mismatch!"
+    log_error "  Expected: ${backup_count}"
+    log_error "  Found: ${cluster_count}"
+    return 1
+  fi
+}
+
+restore_document_processors() {
+  local backup_dir="${1}"
+  local backup_file="${backup_dir}/documentprocessors.yaml"
+  local clean_file="${backup_dir}/documentprocessors-clean.yaml"
+
+  log "Restoring DocumentProcessors from: ${backup_dir}"
+
+  local count
+  count=$(yq eval '.items | length' "${backup_file}" 2>/dev/null || echo 0)
+  log "DocumentProcessors in backup: ${count}"
+
+  if [[ "${count}" -eq 0 ]]; then
+    log "No DocumentProcessors to restore (backup is empty)"
+    return 0
+  fi
+
+  if [[ "${DRY_RUN_JOB}" == "true" ]]; then
+    log "[DRY-RUN] Would strip server fields and execute: kubectl apply -f ${clean_file}"
+    log_success "[DRY-RUN] ${count} DocumentProcessor(s) would be restored"
+    return 0
+  fi
+
+  log "Stripping server-managed fields from backup..."
+  yq eval '
+    del(.items[].metadata.resourceVersion) |
+    del(.items[].metadata.uid) |
+    del(.items[].metadata.creationTimestamp) |
+    del(.items[].metadata.selfLink) |
+    del(.items[].metadata.generation) |
+    del(.items[].metadata.managedFields) |
+    del(.items[].metadata.finalizers) |
+    del(.items[].metadata.annotations["kubectl.kubernetes.io/last-applied-configuration"]) |
+    del(.items[].status)
+  ' "${backup_file}" > "${clean_file}"
+
+  if ! kubectl apply -f "${clean_file}"; then
+    log_error "Failed to restore DocumentProcessors"
+    return 1
+  fi
+
+  log_success "DocumentProcessors restored"
+}
+
+perform_post_migration() {
+  log "=== Starting Post-Migration ==="
+  
+  # Find latest backup
+  local backup_dir
+  backup_dir=$(find_latest_backup) || return 1
+  
+  log "Using backup: ${backup_dir}"
+  
+  # Verify backup exists and is complete
+  verify_backup_exists "${backup_dir}" || return 1
+  
+  # Get database credentials
+  get_database_credentials || return 1
+  
+  # Test database connection
+  test_database_connection || return 1
+  
+  # Restore DataSources
+  restore_datasources "${backup_dir}" || return 1
+  
+  # Restore DocumentProcessors
+  restore_document_processors "${backup_dir}" || return 1
+
+  # Validate DataSource count matches backup
+  validate_datasource_count "${backup_dir}" "${CAS_NAMESPACE}" || return 1
+  
+  # Update database inodes: copy new file_id/pvc_path/path_id from initial-load
+  # rows onto the pre-migration completed rows, then remove the duplicates.
+  log "Updating database inode references..."
+  update_file_table_inodes "${backup_dir}" || return 1
+  
+  # Update state
+  update_migration_progress "post" "completed" || return 1
+  
+  log_success "=== Post-Migration Complete ==="
+}
+
+# ============================================================================
+# 8. MAIN EXECUTION FLOW
+# ============================================================================
+
+main() {
+  log "========================================="
+  log "CAS Data Cache Migration - Job Script"
+  log "========================================="
+  log "Phase: ${MIGRATION_PHASE}"
+  log "Filesystem: ${FILESYSTEM_NAME}"
+  log "Namespace: ${CAS_NAMESPACE}"
+  log "Timestamp: ${MIGRATION_TIMESTAMP}"
+  log "Dry Run: ${DRY_RUN_JOB}"
+  log "========================================="
+  
+  # Install required CLI tools
+  install_cli_tools || {
+    log_error "Failed to install required CLI tools"
+    exit 1
+  }
+  
+  # Validate required environment variables
+  if [[ -z "${MIGRATION_PHASE}" ]] || \
+     [[ -z "${FILESYSTEM_NAME}" ]] || \
+     [[ -z "${CAS_NAMESPACE}" ]] || \
+     [[ -z "${MIGRATION_TIMESTAMP}" ]] || \
+     [[ -z "${MIGRATION_PVC_NAME:-}" ]]; then
+    log_error "Required environment variables not set"
+    exit 1
+  fi
+  
+  # Execute migration based on phase
+  case "${MIGRATION_PHASE}" in
+    pre)
+      perform_pre_migration
+      ;;
+    post)
+      perform_post_migration
+      ;;
+    full)
+      perform_pre_migration || exit 1
+      log ""
+      log "Waiting 5 seconds before post-migration..."
+      sleep 5
+      perform_post_migration
+      ;;
+    *)
+      log_error "Invalid migration phase: ${MIGRATION_PHASE}"
+      log_error "Valid phases: pre, post, full"
+      exit 1
+      ;;
+  esac
+  
+  local exit_code=$?
+  
+  if [[ ${exit_code} -eq 0 ]]; then
+    log "========================================="
+    log "Migration ${MIGRATION_PHASE} completed successfully"
+    log "========================================="
+  else
+    log_error "========================================="
+    log_error "Migration ${MIGRATION_PHASE} failed"
+    log_error "========================================="
+  fi
+  
+  exit ${exit_code}
+}
+
+# Execute main function
+main
+
+# Made with Bob

--- a/CAS/local-data-caching/lib/constants.sh
+++ b/CAS/local-data-caching/lib/constants.sh
@@ -128,7 +128,12 @@ IBM_OPEN_REGISTRY_NS="cpopen"
 # Scale Filesystem Default Values
 #========================================
 DEFAULT_FS_NAME="cache-fs"
-DEFAULT_FS_SIZE="250Gi"
+DEFAULT_FS_SIZE="256Gi"
+
+#========================================
+# CAS Migration Configuration
+#========================================
+MIGRATION_APP_LABEL="cas-data-cache-migration"
 
 #========================================
 # LOCAL_DISK_PVC Configuration
@@ -136,7 +141,7 @@ DEFAULT_FS_SIZE="250Gi"
 LOCAL_DISK_PVC_ACCESS_MODE="ReadWriteMany"
 LOCAL_DISK_PVC_STORAGE_CLASS_SOURCE="ocs-storagecluster-ceph-rbd"
 LOCAL_DISK_PVC_VOLUME_MODE="Block"
-NO_OF_RBD_PVCS=3
+NO_OF_RBD_PVCS=4
 
 #========================================
 # Retry and Timeout Configuration

--- a/CAS/local-data-caching/lib/logging.sh
+++ b/CAS/local-data-caching/lib/logging.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+# Derive the caller's script name (without .sh) before the guard clause so
+# it is captured on first source. Caller may pre-set LOG_FILE_PREFIX to override.
+LOG_FILE_PREFIX="${LOG_FILE_PREFIX:-$(basename "${BASH_SOURCE[1]:-logging}" .sh)}"
+
+# GUARD CLAUSE: Prevent sourcing this file multiple times
+if [[ -n "${LOADED_LOGGING_SH:-}" ]]; then
+    return 0
+fi
+export LOADED_LOGGING_SH=1
+
+#------------------------------------------------------------
+# Logger function
+# Usage: logger [-n] <level> <message>
+# Options: -n (no newline)
+# Levels: info, warn, error, success
+#------------------------------------------------------------
+logger() {
+	local no_newline=false
+	if [[ "$1" == "-n" ]]; then
+		no_newline=true
+		shift
+	fi
+
+	local level="$1"
+	shift
+	local message="$*"
+	local timestamp
+	timestamp=$(date +"%Y-%m-%d %H:%M:%S")
+	local newline="\n"
+	[[ "$no_newline" == true ]] && newline=""
+
+	case "$level" in
+	info)
+		echo -ne "[$timestamp] ℹ️  INFO: $message${newline}" >&2
+		;;
+	warn)
+		echo -ne "[$timestamp] ⚠️  WARNING: $message${newline}" >&2
+		;;
+	error)
+		echo -ne "[$timestamp] ❌ ERROR: $message${newline}" >&2
+		;;
+	success)
+		echo -ne "[$timestamp] ✅ SUCCESS: $message${newline}" >&2
+		;;
+	esac
+}
+
+#------------------------------------------------------------
+# Setup logging (skipped when LOG_TO_FILE=false)
+#------------------------------------------------------------
+if [[ "${LOG_TO_FILE:-true}" == "true" ]]; then
+    LOG_DIR="./logs"
+    LOG_FILE="$LOG_DIR/${LOG_FILE_PREFIX}-$(date +'%Y%m%d_%H%M%S').log"
+
+    mkdir -p "$LOG_DIR"
+
+    exec > >(tee -a "$LOG_FILE") 2>&1
+
+    logger info "Logging initialized. All output will be saved to $LOG_FILE"
+fi

--- a/CAS/local-data-caching/lib/utils.sh
+++ b/CAS/local-data-caching/lib/utils.sh
@@ -23,55 +23,6 @@ help() {
 }
 
 #------------------------------------------------------------
-# Logger function
-# Usage: logger [-n] <level> <message>
-# Options: -n (no newline)
-# Levels: info, warn, error, success
-#------------------------------------------------------------
-logger() {
-	local no_newline=false
-	if [[ "$1" == "-n" ]]; then
-		no_newline=true
-		shift
-	fi
-
-	local level="$1"
-	shift
-	local message="$*"
-	local timestamp
-	timestamp=$(date +"%Y-%m-%d %H:%M:%S")
-	local newline="\n"
-	[[ "$no_newline" == true ]] && newline=""
-
-	case "$level" in
-	info)
-		echo -ne "[$timestamp] ℹ️  INFO: $message${newline}" >&2
-		;;
-	warn)
-		echo -ne "[$timestamp] ⚠️  WARNING: $message${newline}" >&2
-		;;
-	error)
-		echo -ne "[$timestamp] ❌ ERROR: $message${newline}" >&2
-		;;
-	success)
-		echo -ne "[$timestamp] ✅ SUCCESS: $message${newline}" >&2
-		;;
-	esac
-}
-
-#------------------------------------------------------------
-# Setup logging
-#------------------------------------------------------------
-LOG_DIR="./logs"
-LOG_FILE="$LOG_DIR/setup-data-cache-$(date +'%Y%m%d_%H%M%S').log"
-
-mkdir -p "$LOG_DIR"
-
-exec > >(tee -a "$LOG_FILE") 2>&1
-
-logger info "Logging initialized. All output will be saved to $LOG_FILE"
-
-#------------------------------------------------------------
 # get_param_value: Small wrapper around grep+awk
 #------------------------------------------------------------
 get_param_value() {
@@ -246,3 +197,34 @@ wait_for_condition() {
 	done
 }
 
+#------------------------------------------------------------
+# version_gte: Compare two version strings
+# Usage: version_gte A B  →  prints "true"/"false"
+#------------------------------------------------------------
+version_gte() {
+	if [[ "$(printf '%s\n%s\n' "$1" "$2" | sort -V | head -n1)" == "$2" ]]; then
+		echo true
+	else
+		echo false
+	fi
+}
+
+#------------------------------------------------------------
+# compute_script_hash: Compute SHA256 hash of script file
+# Usage: compute_script_hash "/path/to/script.sh"
+# Returns: First 8 characters of SHA256 hash
+#------------------------------------------------------------
+compute_script_hash() {
+	local script_file="${1}"
+
+	if [[ ! -f "${script_file}" ]]; then
+		logger error "Script file not found: ${script_file}"
+		return 1
+	fi
+
+	# Compute SHA256 hash of script contents, take first 8 chars
+	local hash
+	hash=$(sha256sum "${script_file}" | awk '{print $1}' | cut -c1-8)
+	echo "${hash}"
+	return 0
+}

--- a/CAS/local-data-caching/modules/cas_utils.sh
+++ b/CAS/local-data-caching/modules/cas_utils.sh
@@ -6,8 +6,13 @@ if [[ -n "${LOADED_CAS_UTILS_SH:-}" ]]; then
 fi
 export LOADED_CAS_UTILS_SH=1
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
 # shellcheck source=modules/df_utils.sh
-source "$ROOT_DIR/modules/df_utils.sh"
+source "${PROJECT_ROOT}/modules/df_utils.sh"
+# shellcheck source=modules/scale_utils.sh
+source "${PROJECT_ROOT}/modules/scale_utils.sh"
 
 #----------------------------------------
 # Function: Patch the CAS FusionServiceDefinition with the CAS version
@@ -53,43 +58,84 @@ EOF
 }
 
 #----------------------------------------
-# Function: Patch CasInstall with CPU docling/vllm flags
+# Function: Returns true if CAS installation is completed
+# (stage=CAS-INSTALLATION-COMPLETED and progress=100)
+#----------------------------------------
+cas_installed() {
+  local casinstall_json
+  casinstall_json=$(oc get casinstall "${CAS_SERVICE_NAME}" -n "${CAS_NAMESPACE}" -o json 2>/dev/null || true)
+
+  local installation_stage
+  local progress_percentage
+  installation_stage=$(jq -r '.status.installationStage // empty' <<< "${casinstall_json}")
+  progress_percentage=$(jq -r '.status.installStatus.progressPercentage // empty' <<< "${casinstall_json}")
+
+  [[ "${installation_stage}" == "CAS-INSTALLATION-COMPLETED" && "${progress_percentage}" == "100" ]]
+}
+
+#----------------------------------------
+# Function: Returns JSON patch for CasInstall cache and annotation settings
+#----------------------------------------
+patch_cas_install_cache() {
+  local patch
+
+  patch=$(jq -n \
+    --arg sc "${LOCAL_DISK_PVC_STORAGE_CLASS}" \
+    --arg sz "${FILESYSTEM_CAPACITY}" \
+    '{
+      "metadata": {"annotations": {"ignore-filesystem-health-timeout": "true"}},
+      "spec": {"cache": {"storageClass": $sc, "size": $sz}}
+    }')
+
+  # W002: When CAS 1.1.5 has been installed and no Filesystem is found, set the
+  # installation status backwards to force reconciliation from that point.
+  if cas_installed && ! is_fs_created; then
+    patch=$(jq '.status = {"installationStage": "CAS-CORE", "installStatus": {"progressPercentage": 85}}' <<< "${patch}")
+  fi
+
+  echo "${patch}"
+}
+
+#----------------------------------------
+# Function: Returns JSON patch for CasInstall CPU docling/vllm flags
 #----------------------------------------
 patch_cas_install_cpu_flags() {
   local namespace="${1}"
-  local name="${2}"
 
-  # Get RELATED_IMAGE_CAS_DOCLING_CUDA value from cas-operator deployment
-  local docling_image
-  docling_image=$(oc get deployment ibm-isf-cas-operator-controller-manager -n "${namespace}" -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="RELATED_IMAGE_CAS_DOCLING_CUDA")].value}' 2>/dev/null)
-
+  # Use RELATED_IMAGE_CAS_DOCLING_CPU if set, otherwise retrieve from cas-operator deployment
+  local docling_image="${RELATED_IMAGE_CAS_DOCLING_CPU:-}"
   if [[ -z "${docling_image}" ]]; then
-    logger error "Failed to retrieve RELATED_IMAGE_CAS_DOCLING_CUDA from cas-operator deployment in namespace '${namespace}'."
-    return 1
+    # The docling CUDA image can also be used in CPU mode
+    docling_image=$(oc get deployment ibm-isf-cas-operator-controller-manager -n "${namespace}" \
+      -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="RELATED_IMAGE_CAS_DOCLING_CUDA")].value}' 2>/dev/null)
+    if [[ -z "${docling_image}" ]]; then
+      logger error "Failed to retrieve RELATED_IMAGE_CAS_DOCLING_CUDA from cas-operator deployment in namespace '${namespace}'."
+      return 1
+    fi
   fi
 
-  # Get RELATED_IMAGE_CAS_VLLM_CUDA value from cas-operator deployment
-  local vllm_image
-  vllm_image=$(oc get deployment ibm-isf-cas-operator-controller-manager -n "${namespace}" -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="RELATED_IMAGE_CAS_VLLM_CUDA")].value}' 2>/dev/null)
-
+  # Use RELATED_IMAGE_CAS_VLLM_CPU if set, otherwise retrieve from cas-operator deployment
+  local vllm_image="${RELATED_IMAGE_CAS_VLLM_CPU:-}"
   if [[ -z "${vllm_image}" ]]; then
-    logger error "Failed to retrieve RELATED_IMAGE_CAS_VLLM_CUDA from cas-operator deployment in namespace '${namespace}'."
-    return 1
+    vllm_image=$(oc get deployment ibm-isf-cas-operator-controller-manager -n "${namespace}" \
+      -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="RELATED_IMAGE_CAS_VLLM_CPU")].value}' 2>/dev/null)
+    if [[ -z "${vllm_image}" ]]; then
+      logger error "Failed to retrieve RELATED_IMAGE_CAS_VLLM_CPU from cas-operator deployment in namespace '${namespace}'."
+      return 1
+    fi
   fi
 
-  if ! oc patch casinstall "${name}" -n "${namespace}" --type=merge -p '{
-    "spec": {
-      "flags": [
-        "RELATED_IMAGE_CAS_DOCLING_CPU='"${docling_image}"'",
-        "DOCLING_GPU_TYPE=cpu",
-        "RELATED_IMAGE_CAS_VLLM_CPU='"${vllm_image}"'",
-        "VLLM_GPU_TYPE=cpu"
-      ]
-    }
-  }' >/dev/null 2>&1; then
-    logger error "Failed to patch CasInstall '${name}' in namespace '${namespace}'."
-    return 1
-  fi
+  jq -n \
+    --arg docling "RELATED_IMAGE_CAS_DOCLING_CPU=${docling_image}" \
+    --arg vllm "RELATED_IMAGE_CAS_VLLM_CPU=${vllm_image}" \
+    '{"spec": {"flags": [$docling, "DOCLING_GPU_TYPE=cpu", $vllm, "VLLM_GPU_TYPE=cpu"]}}'
+}
+
+#----------------------------------------
+# Function: Returns JSON patch to enable docling multimodal in CasInstall
+#----------------------------------------
+patch_cas_install_docling() {
+  jq -n '{"spec": {"documentProcessingEngine": {"docling_multimodal": {"enabled": true}}}}'
 }
 
 #----------------------------------------
@@ -98,28 +144,33 @@ patch_cas_install_cpu_flags() {
 patch_cas_install() {
   local namespace="${1}"
   local name="${2}"
+  local cas_gte_115="${3}"
+  local cnsa_gte_6010="${4}"
 
-  if ! oc patch casinstall "${name}" -n "${namespace}" --type=merge -p '{
-    "metadata": {
-	  "annotations": {
-	    "ignore-filesystem-health-timeout": "true"
-      }
-	},
-    "spec": {
-      "cache": {
-	   "storageClass": "ocs-storagecluster-ceph-rbd-aof",
-	   "size": "256Gi"
-      }
-	}
-  }' >/dev/null 2>&1; then
-    logger error "Failed to patch CasInstall '${name}' in namespace '${namespace}'."
-    return 1
+  local patch="{}"
+
+  if [[ "${CAS_ENABLE_DOCLING}" == "true" ]]; then
+    local docling_patch
+    docling_patch="$(patch_cas_install_docling)"
+    patch="$(jq -s '.[0] * .[1]' <(echo "${patch}") <(echo "${docling_patch}"))"
   fi
 
-  # Patch CAS install to use CPU, if configured
+  if [[ "${cas_gte_115}" == true ]] && [[ "${cnsa_gte_6010}" == true ]]; then
+    local cache_patch
+    cache_patch="$(patch_cas_install_cache)"
+    patch="$(jq -s '.[0] * .[1]' <(echo "${patch}") <(echo "${cache_patch}"))"
+  fi
+
   if [[ "${CAS_RHAI_USE_CPU}" == "true" ]]; then
     logger info "Patching CasInstall to use CPU for RHAI"
-    patch_cas_install_cpu_flags "${namespace}" "${name}"
+    local cpu_patch
+    cpu_patch="$(patch_cas_install_cpu_flags "${namespace}")" || return 1
+    patch="$(jq -s '.[0] * .[1]' <(echo "${patch}") <(echo "${cpu_patch}"))"
+  fi
+
+  if ! oc patch casinstall "${name}" -n "${namespace}" --type=merge -p "${patch}" >/dev/null 2>&1; then
+    logger error "Failed to patch CasInstall '${name}' in namespace '${namespace}'."
+    return 1
   fi
 }
 
@@ -134,6 +185,16 @@ wait_for_casinstall() {
     "Waiting for CasInstall CR '${name}' in namespace '${namespace}'" \
     "${CAS_INSTALL_TIMEOUT}" \
     "oc get casinstall '${name}' -n '${namespace}'"
+}
+
+#----------------------------------------
+# Function: Verify CAS installation from FSI succeeds
+#----------------------------------------
+verify_cas_install() {
+  wait_for_condition \
+    "Waiting for CAS installation to complete" \
+    "${CAS_SERVICE_TIMEOUT}" \
+    "[[ \$(oc get casinstall '${CAS_SERVICE_NAME}' -n '${CAS_NAMESPACE}' -o jsonpath='{.status.installationStage}' 2>/dev/null) == 'CAS-INSTALLATION-COMPLETED' ]] && [[ \$(oc get casinstall '${CAS_SERVICE_NAME}' -n '${CAS_NAMESPACE}' -o jsonpath='{.status.installStatus.progressPercentage}' 2>/dev/null) == '100' ]]"
 }
 
 #----------------------------------------
@@ -195,4 +256,139 @@ EOF
   fi
 
   logger success "Scale watch configured"
+}
+
+#----------------------------------------
+# Function: Get installed CAS version from CSV
+#----------------------------------------
+get_cas_version() {
+	local ver
+	ver=$(oc get csv -A --no-headers \
+		-o custom-columns=NAME:.metadata.name,VERSION:.spec.version 2>/dev/null \
+		| grep "ibm-isf-cas-operator" | awk '{print $2}' | head -n1)
+	echo "${ver#v}"
+}
+
+#----------------------------------------
+# Function: Validate CAS namespace exists
+#----------------------------------------
+validate_cas_namespace() {
+	local cas_namespace="${1}"
+	
+	logger info "Validating CAS namespace..."
+	
+	if ! oc get namespace "${cas_namespace}" &>/dev/null; then
+		logger error "CAS namespace not found: ${cas_namespace}"
+		logger error "This is the target namespace where the migration job will run"
+		return 1
+	fi
+	
+	logger success "CAS namespace validated: ${cas_namespace}"
+	return 0
+}
+
+#----------------------------------------
+# Function: Get migration state for a phase
+#----------------------------------------
+get_migration_state() {
+	local namespace="${1}"
+	local phase="${2}"
+	
+	# Check for running jobs
+	local active_jobs
+	active_jobs=$(oc get jobs -n "${namespace}" \
+		-l "app=${MIGRATION_APP_LABEL},migration-phase=${phase}" \
+		-o jsonpath='{.items[?(@.status.active>0)].metadata.name}' 2>/dev/null || echo "")
+	
+	if [[ -n "${active_jobs}" ]]; then
+		echo "running"
+		return 0
+	fi
+	
+	# Check for succeeded jobs
+	local succeeded_jobs
+	succeeded_jobs=$(oc get jobs -n "${namespace}" \
+		-l "app=${MIGRATION_APP_LABEL},migration-phase=${phase}" \
+		-o jsonpath='{.items[?(@.status.succeeded>0)].metadata.name}' 2>/dev/null || echo "")
+	
+	if [[ -n "${succeeded_jobs}" ]]; then
+		echo "completed"
+		return 0
+	fi
+	
+	# Check for failed jobs
+	local failed_jobs
+	failed_jobs=$(oc get jobs -n "${namespace}" \
+		-l "app=${MIGRATION_APP_LABEL},migration-phase=${phase}" \
+		-o jsonpath='{.items[?(@.status.failed>0)].metadata.name}' 2>/dev/null || echo "")
+	
+	if [[ -n "${failed_jobs}" ]]; then
+		echo "failed"
+		return 0
+	fi
+	
+	echo "pending"
+	return 0
+}
+
+#----------------------------------------
+# Function: Check migration state and handle accordingly
+#----------------------------------------
+check_migration_state() {
+	local namespace="${1}"
+	local phase="${2}"
+	
+	logger info "Checking migration state for ${phase}-migration..."
+	
+	local current_state
+	current_state=$(get_migration_state "${namespace}" "${phase}")
+	
+	case "${current_state}" in
+		running)
+			local running_job
+			running_job=$(oc get jobs -n "${namespace}" \
+				-l "app=${MIGRATION_APP_LABEL},migration-phase=${phase}" \
+				-o jsonpath='{.items[?(@.status.active>0)].metadata.name}' 2>/dev/null)
+			
+			logger error "${phase}-migration already running: ${running_job}"
+			logger error "Check status: oc get job ${running_job} -n ${namespace}"
+			return 1
+			;;
+		
+		completed)
+			local completed_job
+			completed_job=$(oc get jobs -n "${namespace}" \
+				-l "app=${MIGRATION_APP_LABEL},migration-phase=${phase}" \
+				-o jsonpath='{.items[?(@.status.succeeded>0)].metadata.name}' 2>/dev/null | head -n1)
+			
+			logger warn "${phase}-migration already completed: ${completed_job}"
+			read -p "Re-run migration? (yes/no): " -r
+			if [[ ! $REPLY =~ ^[Yy]es$ ]]; then
+				logger info "Cancelled by user"
+				return 1
+			fi
+			;;
+		
+		failed)
+			local failed_job
+			failed_job=$(oc get jobs -n "${namespace}" \
+				-l "app=${MIGRATION_APP_LABEL},migration-phase=${phase}" \
+				-o jsonpath='{.items[?(@.status.failed>0)].metadata.name}' 2>/dev/null | head -n1)
+			
+			logger warn "Previous ${phase}-migration failed: ${failed_job}"
+			logger warn "Review logs: oc logs job/${failed_job} -n ${namespace}"
+			read -p "Retry migration? (yes/no): " -r
+			if [[ ! $REPLY =~ ^[Yy]es$ ]]; then
+				logger info "Cancelled by user"
+				return 1
+			fi
+			;;
+		
+		pending)
+			logger info "No previous ${phase}-migration found"
+			;;
+	esac
+	
+	logger success "State check passed (current: ${current_state})"
+	return 0
 }

--- a/CAS/local-data-caching/modules/df_utils.sh
+++ b/CAS/local-data-caching/modules/df_utils.sh
@@ -7,12 +7,15 @@ if [[ -n "${LOADED_DF_UTILS_SH:-}" ]]; then
 fi
 export LOADED_DF_UTILS_SH=1
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
+# shellcheck source=lib/logging.sh
+source "${PROJECT_ROOT}/lib/logging.sh"
 # shellcheck source=lib/utils.sh
-source "${SCRIPT_DIR}/../lib/utils.sh"
+source "${PROJECT_ROOT}/lib/utils.sh"
 
 # shellcheck source=config/config.env
-source "$ROOT_DIR/config/config.env"
+source "${PROJECT_ROOT}/config/config.env"
 
 #========================================
 # OpenShift Data Foundation Utility Functions
@@ -26,6 +29,7 @@ source "$ROOT_DIR/config/config.env"
 #   4. create_pvc_local_disks()
 #   5. create_expose_rbd_daemonset()
 #   6. convert_hdd_to_ssd()
+#   7. get_odf_version()
 #========================================
 
 #----------------------------------------
@@ -142,8 +146,7 @@ configure_fdf() {
 # Function: Patch Ceph CSI drivers (RBD and CephFS)
 #----------------------------------------
 patch_ceph_csi_drivers() {
-	drivers=("rbd" "cephfs")
-	for driver in "${drivers[@]}"; do
+	for driver in rbd cephfs; do
 		if oc get -n "$OCS_NAMESPACE" "driver.csi.ceph.io/openshift-storage.${driver}.csi.ceph.com" &>/dev/null; then
 			patch_ceph_csi_driver "$driver"
 		fi
@@ -216,43 +219,52 @@ delete_scale_rbd_sc() {
 }
 
 #----------------------------------------
-# Function: Create PVCs for local disks
+# Helper: Emit YAML for all local-disk PVCs
 #----------------------------------------
-create_pvc_local_disks() {
+rbd_pvcs_yaml() {
+	local pvc_size
+	pvc_size=$(( FILESYSTEM_CAPACITY / NO_OF_RBD_PVCS ))
 	local i=1
-	local pvc_names
 	while (( i <= NO_OF_RBD_PVCS )); do
-		local pvc_name="local-disk${i}"
-		cat <<EOF | oc apply -f -
+		cat <<EOF
+---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: ${pvc_name}
+  name: local-disk${i}
   namespace: ${LOCAL_STORAGE_PROJECT}
 spec:
   accessModes:
     - ${LOCAL_DISK_PVC_ACCESS_MODE}
   resources:
     requests:
-      storage: ${FILESYSTEM_CAPACITY}
+      storage: ${pvc_size}
   storageClassName: ${LOCAL_DISK_PVC_STORAGE_CLASS}
   volumeMode: ${LOCAL_DISK_PVC_VOLUME_MODE}
 EOF
-		pvc_names+="${pvc_name} "
 		((++i))
 	done
+}
+
+#----------------------------------------
+# Function: Create PVCs for local disks
+#----------------------------------------
+create_pvc_local_disks() {
+	rbd_pvcs_yaml | oc apply -f -
 
 	local interval=10 # 10 seconds
 	while true; do
 		local unbound_pvcs=""
 		local i=1
 
-		for pvc_name in ${pvc_names}; do
+		while (( i <= NO_OF_RBD_PVCS )); do
+			local pvc_name="local-disk${i}"
 			local pvc_phase
 			pvc_phase="$(oc get pvc -n "${LOCAL_STORAGE_PROJECT}" "${pvc_name}" -ojsonpath='{.status.phase}')"
 			if [[ "${pvc_phase}"  != "Bound" ]]; then
 				unbound_pvcs+="${pvc_name} "
 			fi
+			((++i))
 		done
 
 		if [[ "${unbound_pvcs}" == "" ]]; then
@@ -310,4 +322,15 @@ convert_hdd_to_ssd() {
 			done
 		' >/dev/null 2>&1
 	done
+}
+
+#----------------------------------------
+# Function: Get installed ODF version from subscription
+#----------------------------------------
+get_odf_version() {
+	local ver
+	ver=$(oc get subscription odf-operator -n "$OCS_NAMESPACE" \
+		-o jsonpath='{.status.currentCSV}' 2>/dev/null \
+		| grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
+	echo "${ver#v}"
 }

--- a/CAS/local-data-caching/modules/fusion_utils.sh
+++ b/CAS/local-data-caching/modules/fusion_utils.sh
@@ -7,6 +7,10 @@ if [[ -n "${LOADED_FUSION_UTILS_SH:-}" ]]; then
 fi
 export LOADED_FUSION_UTILS_SH=1
 
+PROJECT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=lib/logging.sh
+source "${PROJECT_DIR}/lib/logging.sh"
+
 #========================================
 # IBM Spectrum Fusion Utility Functions
 #========================================
@@ -22,6 +26,7 @@ export LOADED_FUSION_UTILS_SH=1
 #   7. deploy_fsi()
 #   8. deploy_scale_service()
 #   9. is_scale_deployed()
+#  10. get_fusion_version()
 #========================================
 
 #----------------------------------------
@@ -249,3 +254,13 @@ is_scale_deployed() {
 	fi
 }
 
+#----------------------------------------
+# Function: Get installed Fusion version from CSV
+#----------------------------------------
+get_fusion_version() {
+	local ver
+	ver=$(oc get csv -A --no-headers \
+		-o custom-columns=NAME:.metadata.name,VERSION:.spec.version 2>/dev/null \
+		| grep "$FUSION_PACKAGE_NAME" | awk '{print $2}' | head -n1)
+	echo "${ver#v}"
+}

--- a/CAS/local-data-caching/modules/ocp_cluster_utils.sh
+++ b/CAS/local-data-caching/modules/ocp_cluster_utils.sh
@@ -7,6 +7,10 @@ if [[ -n "${LOADED_OCP_UTILS_SH:-}" ]]; then
 fi
 export LOADED_OCP_UTILS_SH=1
 
+PROJECT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=lib/logging.sh
+source "${PROJECT_DIR}/lib/logging.sh"
+
 #----------------------------------------
 # Function: Check cluster connectivity
 #----------------------------------------
@@ -177,4 +181,168 @@ get_node_for_pod() {
 get_pv_from_pvc() {
 	local pvc="$1"
 	oc get pvc "$pvc" -n "${LOCAL_STORAGE_PROJECT}" -o jsonpath='{.spec.volumeName}' 2>/dev/null || echo ""
+}
+
+#----------------------------------------
+# Function: Wait for job completion with timeout
+#----------------------------------------
+wait_for_job_completion() {
+	local job_name="${1}"
+	local namespace="${2}"
+	local timeout="${3:-1800}"
+
+	logger info "Monitoring Job: ${job_name}"
+	logger info "Timeout: ${timeout}s"
+
+	local start_time
+	start_time=$(date +%s)
+
+	while true; do
+		local elapsed
+		elapsed=$(($(date +%s) - start_time))
+
+		if [[ ${elapsed} -ge ${timeout} ]]; then
+			logger error "Timeout reached (${timeout}s)"
+			return 1
+		fi
+
+		local status
+		status=$(oc get job "${job_name}" -n "${namespace}" \
+			-o jsonpath='{.status.conditions[?(@.type=="Complete")].status}' 2>/dev/null)
+
+		if [[ "${status}" == "True" ]]; then
+			logger success "Job completed successfully"
+			return 0
+		fi
+
+		local failed
+		failed=$(oc get job "${job_name}" -n "${namespace}" \
+			-o jsonpath='{.status.conditions[?(@.type=="Failed")].status}' 2>/dev/null)
+
+		if [[ "${failed}" == "True" ]]; then
+			logger error "Job failed"
+			return 1
+		fi
+
+		if [[ $((elapsed % 30)) -eq 0 ]]; then
+			logger info "Still running... (${elapsed}s elapsed)"
+		fi
+
+		sleep 5
+	done
+}
+
+#----------------------------------------
+# Function: Wait for job pod to start creating successfully
+#----------------------------------------
+wait_for_job_pod_ready() {
+	local job_name="${1}"
+	local namespace="${2}"
+	local timeout="${3:-60}"
+
+	logger info "Waiting for Job pod to be created: ${job_name}"
+
+	local start_time
+	start_time=$(date +%s)
+
+	while true; do
+		local elapsed
+		elapsed=$(($(date +%s) - start_time))
+
+		if [[ ${elapsed} -ge ${timeout} ]]; then
+			logger error "Timed out waiting for Job pod (${timeout}s)"
+			return 1
+		fi
+
+		local pod_name
+		pod_name=$(oc get pods -n "${namespace}" \
+			-l "job-name=${job_name}" \
+			-o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo "")
+
+		if [[ -z "${pod_name}" ]]; then
+			sleep 2
+			continue
+		fi
+
+		local waiting_reason
+		waiting_reason=$(oc get pod "${pod_name}" -n "${namespace}" \
+			-o jsonpath='{.status.containerStatuses[0].state.waiting.reason}' 2>/dev/null || echo "")
+
+		local terminated_reason
+		terminated_reason=$(oc get pod "${pod_name}" -n "${namespace}" \
+			-o jsonpath='{.status.containerStatuses[0].state.terminated.reason}' 2>/dev/null || echo "")
+
+		if [[ -n "${terminated_reason}" ]]; then
+			local started
+			started=$(oc get pod "${pod_name}" -n "${namespace}" \
+				-o jsonpath='{.status.containerStatuses[0].started}' 2>/dev/null || echo "")
+
+			if [[ "${started}" == "true" ]]; then
+				logger info "Job pod already started before terminating: ${pod_name} (${terminated_reason})"
+				return 0
+			fi
+
+			logger error "Job pod terminated before logs could be streamed: ${pod_name} (${terminated_reason})"
+			return 1
+		fi
+
+		case "${waiting_reason}" in
+			""|ContainerCreating|PodInitializing)
+				sleep 2
+				;;
+			CrashLoopBackOff|CreateContainerConfigError|CreateContainerError|ErrImagePull|ImagePullBackOff|RunContainerError|StartError)
+				logger error "Job pod failed before logs could be streamed: ${pod_name} (${waiting_reason})"
+				return 1
+				;;
+			*)
+				sleep 2
+				;;
+		esac
+
+		local started
+		started=$(oc get pod "${pod_name}" -n "${namespace}" \
+			-o jsonpath='{.status.containerStatuses[0].started}' 2>/dev/null || echo "")
+
+		if [[ "${started}" == "true" ]]; then
+			logger success "Job pod is ready for log streaming: ${pod_name}"
+			return 0
+		fi
+	done
+}
+
+#----------------------------------------
+# Function: Stream logs from job pod
+#----------------------------------------
+stream_job_logs() {
+	local job_name="${1}"
+	local namespace="${2}"
+
+	logger info "Streaming logs from: ${job_name}"
+
+	# Wait for pod
+	local pod_name=""
+	local retries=0
+	while [[ -z "${pod_name}" ]] && [[ ${retries} -lt 30 ]]; do
+		pod_name=$(oc get pods -n "${namespace}" \
+			-l "job-name=${job_name}" \
+			-o jsonpath='{.items[0].metadata.name}' 2>/dev/null)
+
+		if [[ -z "${pod_name}" ]]; then
+			sleep 2
+			retries=$((retries + 1))
+		fi
+	done
+
+	if [[ -z "${pod_name}" ]]; then
+		logger error "Pod not found for job"
+		return 1
+	fi
+
+	logger info "Pod: ${pod_name}"
+	logger info "--- Logs Start ---"
+
+	oc logs -f "pod/${pod_name}" -n "${namespace}" 2>&1 || true
+
+	logger info "--- Logs End ---"
+	return 0
 }

--- a/CAS/local-data-caching/modules/olm_utils.sh
+++ b/CAS/local-data-caching/modules/olm_utils.sh
@@ -7,6 +7,10 @@ if [[ -n "${LOADED_OLM_UTILS_SH:-}" ]]; then
 fi
 export LOADED_OLM_UTILS_SH=1
 
+PROJECT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=lib/logging.sh
+source "${PROJECT_DIR}/lib/logging.sh"
+
 #----------------------------------------
 # Function: Check if Fusion operator is installed (HCI or SDS)
 #----------------------------------------

--- a/CAS/local-data-caching/modules/scale_utils.sh
+++ b/CAS/local-data-caching/modules/scale_utils.sh
@@ -7,6 +7,10 @@ if [[ -n "${LOADED_SCALE_UTILS_SH:-}" ]]; then
 fi
 export LOADED_SCALE_UTILS_SH=1
 
+PROJECT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=lib/logging.sh
+source "${PROJECT_DIR}/lib/logging.sh"
+
 #========================================
 # IBM Spectrum Scale Utility Functions
 #========================================
@@ -45,6 +49,10 @@ export LOADED_SCALE_UTILS_SH=1
 #
 #   Configuration:
 #    19. scale_set_config()
+#
+#   Version Detection:
+#    20. cnsa_product_to_csv()
+#    21. get_cnsa_version()
 #========================================
 
 #========================================
@@ -136,7 +144,7 @@ get_device_id() {
 get_device_ids_for_local_disks() {
 	local devices
 	devices=$(get_rbd_devices)
-	DEVICE_IDS=()
+	DEVICE_IDS=""
 
 	for pvc in local-disk1 local-disk2 local-disk3; do
 		local pv pool img dev
@@ -145,13 +153,13 @@ get_device_ids_for_local_disks() {
 		dev=$(get_device_id "$devices" "$pool" "$img")
 
 		if [[ -n "$dev" ]]; then
-			DEVICE_IDS+=("$dev")
+			DEVICE_IDS="${DEVICE_IDS}${DEVICE_IDS:+ }${dev}"
 		else
 			logger warn "No device found for PVC: $pvc"
 		fi
 	done
 
-	if [[ ${#DEVICE_IDS[@]} -eq 0 ]]; then
+	if [[ -z "$DEVICE_IDS" ]]; then
 		logger error "No RBD device IDs found for any local-disk PVCs"
 		return 1
 	fi
@@ -247,7 +255,9 @@ verify_scale_cluster() {
 # Function: Patch device regex in Scale cluster CR
 #----------------------------------------
 patch_device_regex_in_scale_cluster() {
-	local first="${DEVICE_IDS[0]}"
+	# shellcheck disable=SC2086  # intentional word-split of space-separated string
+	set -- $DEVICE_IDS
+	local first="$1"
 	local prefix="${first%%[0-9]*}"
 	local pattern="${prefix}*"
 
@@ -273,7 +283,7 @@ create_local_disks() {
 
 	logger info "Creating LocalDisk CRs on node '$node'..."
 
-	for dev in "${DEVICE_IDS[@]}"; do
+	for dev in $DEVICE_IDS; do
 		cat <<EOF | oc apply -f -
 apiVersion: scale.spectrum.ibm.com/v1beta1
 kind: LocalDisk
@@ -385,7 +395,23 @@ is_fs_created() {
 # Function: Create Spectrum Scale FileSystem
 #----------------------------------------
 create_fs() {
-	if ! envsubst <templates/filesystem.yaml | oc apply -f - >/dev/null 2>&1; then
+	CNSA_GTE_6010="${1:-false}"
+
+	# CNSA < 60.1.0: does not manage LocalDisk PVCs
+	if [[ "${CNSA_GTE_6010}" == false ]]; then
+		get_device_ids_for_local_disks
+		patch_device_regex_in_scale_cluster
+		ensure_local_disks
+	fi
+
+	local fs_manifest
+	fs_manifest=$(envsubst <templates/filesystem.yaml)
+
+	if [[ "${CNSA_GTE_6010}" == true ]]; then
+		fs_manifest=$(yq e ".spec.local.pools[0].deviceVolumes = {\"capacity\": \"${FILESYSTEM_CAPACITY}\", \"storageClass\": \"${LOCAL_DISK_PVC_STORAGE_CLASS}\"}" - <<< "${fs_manifest}")
+	fi
+
+	if ! oc apply -f - >/dev/null 2>&1 <<< "${fs_manifest}"; then
 		logger error "Failed to create Spectrum Scale FileSystem '${FILESYSTEM_NAME}'."
 		return 1
 	fi
@@ -397,7 +423,7 @@ create_fs() {
 verify_fs() {
 	logger info "Verifying Spectrum Scale FileSystem status..."
 
-	local timeout=900 # 15 minutes
+	local timeout=1800 # 30 minutes
 	local interval=30
 	local elapsed=0
 
@@ -498,4 +524,26 @@ scale_set_config() {
 	if [[ "${found_value}" != "${VALUE}" ]]; then
 		scale_core_exec "mmchconfig ${OPT}=${VALUE} --force -i"
 	fi
+}
+
+#========================================
+# Version Detection
+#========================================
+
+#----------------------------------------
+# Function: Transform CNSA product version (6.0.y.z) to CSV format (60.y.z)
+#----------------------------------------
+cnsa_product_to_csv() {
+	echo "$1" | awk -F. '{printf "%d%d.%s.%s\n", $1, $2, $3, $4}'
+}
+
+#----------------------------------------
+# Function: Get installed CNSA version from CSV (in CSV format: 60.x.y)
+#----------------------------------------
+get_cnsa_version() {
+	local ver
+	ver=$(oc get csv -A --no-headers \
+		-o custom-columns=NAME:.metadata.name,VERSION:.spec.version 2>/dev/null \
+		| grep "ibm-spectrum-scale-operator" | awk '{print $2}' | head -n1)
+	echo "${ver#v}"
 }

--- a/CAS/local-data-caching/templates/filesystem.yaml
+++ b/CAS/local-data-caching/templates/filesystem.yaml
@@ -9,12 +9,7 @@ metadata:
 spec:
   local:
     blockSize: 4M
-    pools:
-    - disks:
-      - disk0
-      - disk1
-      - disk2
-      name: system
+    pools: []
     replication: 1-way
     type: shared
   seLinuxOptions:

--- a/CAS/local-data-caching/templates/migration/cas_migration_configmap.yaml
+++ b/CAS/local-data-caching/templates/migration/cas_migration_configmap.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ${MIGRATION_CM_NAME}
+  namespace: ${CAS_NAMESPACE}
+  labels:
+    app: ${MIGRATION_APP_LABEL}
+    migration-phase: ${MIGRATION_PHASE}
+data:
+  migration.sh: |
+${MIGRATION_SCRIPT}

--- a/CAS/local-data-caching/templates/migration/cas_migration_job.yaml
+++ b/CAS/local-data-caching/templates/migration/cas_migration_job.yaml
@@ -1,0 +1,72 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ${JOB_NAME}
+  namespace: ${CAS_NAMESPACE}
+  labels:
+    app: ${MIGRATION_APP_LABEL}
+    migration-phase: ${MIGRATION_PHASE}
+    migration-timestamp: "${MIGRATION_TIMESTAMP}"
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        app: ${MIGRATION_APP_LABEL}
+        app.kubernetes.io/name: cas.isf.ibm.com
+        migration-phase: ${MIGRATION_PHASE}
+        job-name: ${JOB_NAME}
+    spec:
+      restartPolicy: Never
+      serviceAccountName: cas-migration-sa
+      securityContext:
+        runAsUser: 0
+        runAsGroup: 0
+        fsGroup: 0
+      containers:
+      - name: migration
+        image: registry.access.redhat.com/ubi9/ubi-minimal:latest
+        securityContext:
+          runAsUser: 0
+          allowPrivilegeEscalation: false
+        command:
+        - /bin/bash
+        - /scripts/migration.sh
+        env:
+        - name: MIGRATION_PHASE
+          value: "${MIGRATION_PHASE}"
+        - name: FILESYSTEM_NAME
+          value: "${FILESYSTEM_NAME}"
+        - name: CAS_NAMESPACE
+          value: "${CAS_NAMESPACE}"
+        - name: SCALE_NAMESPACE
+          value: "${SCALE_NAMESPACE}"
+        - name: MIGRATION_TIMESTAMP
+          value: "${MIGRATION_TIMESTAMP}"
+        - name: JOB_NAME
+          value: "${JOB_NAME}"
+        - name: MIGRATION_PVC_NAME
+          value: "${MIGRATION_PVC_NAME}"
+        - name: DRY_RUN_JOB
+          value: "${DRY_RUN_JOB}"
+        volumeMounts:
+        - name: migration-scripts
+          mountPath: /scripts
+          readOnly: true
+        - name: pvc-volume
+          mountPath: /mnt/${MIGRATION_PVC_NAME}
+        resources:
+          requests:
+            memory: "256Mi"
+            cpu: "100m"
+          limits:
+            memory: "256Mi"
+            cpu: "100m"
+      volumes:
+      - name: migration-scripts
+        configMap:
+          name: ${MIGRATION_CM_NAME}
+          defaultMode: 493
+      - name: pvc-volume
+        persistentVolumeClaim:
+          claimName: ${MIGRATION_PVC_NAME}

--- a/CAS/local-data-caching/templates/migration/cas_migration_networkpolicy.yaml
+++ b/CAS/local-data-caching/templates/migration/cas_migration_networkpolicy.yaml
@@ -1,0 +1,40 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: cas-migration-network-policy
+  namespace: ${CAS_NAMESPACE}
+  labels:
+    app: ${MIGRATION_APP_LABEL}
+spec:
+  podSelector:
+    matchLabels:
+      app: ${MIGRATION_APP_LABEL}
+  policyTypes:
+  - Egress
+  egress:
+  # Allow DNS (port 53 to Service ClusterIP; port 5353 is the CoreDNS pod targetPort)
+  - ports:
+    - port: 53
+      protocol: UDP
+    - port: 53
+      protocol: TCP
+    - port: 5353
+      protocol: UDP
+    - port: 5353
+      protocol: TCP
+  # Allow Kubernetes API
+  - ports:
+    - port: 443
+      protocol: TCP
+    - port: 6443
+      protocol: TCP
+  # Allow PostgreSQL
+  - to:
+    - podSelector:
+        matchLabels:
+          cnpg.io/cluster: cluster-parade
+    ports:
+    - port: 5432
+      protocol: TCP
+
+# Made with Bob

--- a/CAS/local-data-caching/templates/migration/cas_migration_rbac.yaml
+++ b/CAS/local-data-caching/templates/migration/cas_migration_rbac.yaml
@@ -1,0 +1,132 @@
+# ServiceAccount used by the migration Job pod
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cas-migration-sa
+  namespace: ${CAS_NAMESPACE}
+  labels:
+    app: ${MIGRATION_APP_LABEL}
+---
+# ClusterRole granting use of the anyuid SCC.
+# anyuid allows runAsUser: 0 / fsGroup: 0 which the migration container
+# requires to install tools (microdnf) and write to /usr/local/bin.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cas-migration-anyuid-scc-use
+  labels:
+    app: ${MIGRATION_APP_LABEL}
+rules:
+- apiGroups:
+  - security.openshift.io
+  resources:
+  - securitycontextconstraints
+  resourceNames:
+  - anyuid
+  verbs:
+  - use
+---
+# ClusterRoleBinding: grants cas-migration-sa the anyuid SCC use ClusterRole.
+# Must be cluster-scoped because SCCs are cluster-scoped resources.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cas-migration-anyuid-scc-use
+  labels:
+    app: ${MIGRATION_APP_LABEL}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cas-migration-anyuid-scc-use
+subjects:
+- kind: ServiceAccount
+  name: cas-migration-sa
+  namespace: ${CAS_NAMESPACE}
+---
+# Role: namespaced permissions the migration Job pod needs to call the
+# Kubernetes API from inside the cluster.
+#
+# Verbs breakdown:
+#   configmaps         - read migration state, write progress marker (get/list/watch/create/patch/update)
+#   secrets            - read cluster-parade-app DB credentials (get/watch)
+#   datasources        - backup (get/list/watch), patch finalizers, restore via apply (create/update/patch/delete)
+#   deployments        - scale operator down/up (get/list/watch/patch/update)
+#   documentprocessors - delete before filesystem teardown; read domain state (get/list/watch/delete)
+#   domains            - read domain state (get/list/watch/delete)
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cas-migration-role
+  namespace: ${CAS_NAMESPACE}
+  labels:
+    app: ${MIGRATION_APP_LABEL}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - watch
+- apiGroups:
+  - cas.isf.ibm.com
+  resources:
+  - datasources
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - patch
+  - update
+  - delete
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - deployments/scale
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+  - update
+- apiGroups:
+  - cas.isf.ibm.com
+  resources:
+  - documentprocessors
+  - domains
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+---
+# RoleBinding: binds cas-migration-role to cas-migration-sa in CAS_NAMESPACE
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cas-migration-role-binding
+  namespace: ${CAS_NAMESPACE}
+  labels:
+    app: ${MIGRATION_APP_LABEL}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cas-migration-role
+subjects:
+- kind: ServiceAccount
+  name: cas-migration-sa
+  namespace: ${CAS_NAMESPACE}

--- a/CAS/local-data-caching/tests/test_match_expressions.sh
+++ b/CAS/local-data-caching/tests/test_match_expressions.sh
@@ -10,6 +10,8 @@ export ROOT_DIR
 # Source required files
 # shellcheck source=../lib/constants.sh
 source "$ROOT_DIR/lib/constants.sh"
+# shellcheck source=../lib/logging.sh
+source "$ROOT_DIR/lib/logging.sh"
 # shellcheck source=../lib/utils.sh
 source "$ROOT_DIR/lib/utils.sh"
 # shellcheck source=../modules/df_utils.sh
@@ -20,16 +22,13 @@ source "$ROOT_DIR/config/config.env"
 # Set required environment variable
 #export OCS_BACKING_STORAGECLASS="ocs-backing-lvs"
 
-# Array of test match expressions
-test_expressions=(
-    "Exists:node-role.kubernetes.io/worker"
-    "NotIn:beta.kubernetes.io/instance-type=gx3d.160x1792.8h100,another.type"
-    "In:region=us-east,us-west"
-    "Exists:node-role.kubernetes.io/worker;NotIn:beta.kubernetes.io/instance-type=gx3d.160x1792.8h100"
-)
-
 # Loop through each test expression
-for STORAGE_NODE_MATCH in "${test_expressions[@]}"; do
+for STORAGE_NODE_MATCH in \
+    "Exists:node-role.kubernetes.io/worker" \
+    "NotIn:beta.kubernetes.io/instance-type=gx3d.160x1792.8h100,another.type" \
+    "In:region=us-east,us-west" \
+    "Exists:node-role.kubernetes.io/worker;NotIn:beta.kubernetes.io/instance-type=gx3d.160x1792.8h100" \
+; do
     echo "========================================"
     echo "STORAGE_NODE_MATCH: ${STORAGE_NODE_MATCH}"
     echo "========================================"

--- a/CAS/local-data-caching/tests/test_migrate_cas_filesystem.sh
+++ b/CAS/local-data-caching/tests/test_migrate_cas_filesystem.sh
@@ -1,0 +1,336 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+
+# Load configuration and utilities
+set -a
+# shellcheck source=lib/constants.sh
+source "$ROOT_DIR/lib/constants.sh"
+# shellcheck source=config/config.env
+source "$ROOT_DIR/config/config.env"
+set +a
+
+# shellcheck source=lib/logging.sh
+source "$ROOT_DIR/lib/logging.sh"
+# shellcheck source=lib/utils.sh
+source "$ROOT_DIR/lib/utils.sh"
+
+# Load functions from migrate-data-cache.sh without executing main
+# We extract only the functions we need to test
+
+require_argument_value() {
+	local option="$1"
+	local value="${2:-}"
+
+	if [[ -z "$value" || "$value" == --* ]]; then
+		logger error "Option ${option} requires a value"
+		return 1
+	fi
+}
+
+parse_arguments() {
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--migration-phase)
+			require_argument_value "$1" "${2:-}"
+			MIGRATION_PHASE="$2"
+			shift 2
+			;;
+		--filesystem-name)
+			require_argument_value "$1" "${2:-}"
+			FILESYSTEM_NAME="$2"
+			shift 2
+			;;
+		--cas-namespace)
+			require_argument_value "$1" "${2:-}"
+			CAS_NAMESPACE="$2"
+			shift 2
+			;;
+		--scale-namespace)
+			require_argument_value "$1" "${2:-}"
+			SCALE_NAMESPACE="$2"
+			shift 2
+			;;
+		--job-name)
+			require_argument_value "$1" "${2:-}"
+			JOB_NAME="$2"
+			shift 2
+			;;
+		--timeout)
+			require_argument_value "$1" "${2:-}"
+			JOB_TIMEOUT="$2"
+			shift 2
+			;;
+		--skip-validation)
+			SKIP_VALIDATION=true
+			shift
+			;;
+		--dry-run)
+			DRY_RUN=true
+			shift
+			;;
+		--help | -h)
+			return 0
+			;;
+		*)
+			logger error "Unknown option: $1"
+			return 1
+			;;
+		esac
+	done
+
+	if [[ -z "${MIGRATION_PHASE}" ]]; then
+		logger error "--migration-phase is required"
+		return 1
+	fi
+
+	if [[ ! "${MIGRATION_PHASE}" =~ ^(pre|post|full)$ ]]; then
+		logger error "Invalid phase: ${MIGRATION_PHASE}"
+		logger error "Must be: pre, post, or full"
+		return 1
+	fi
+}
+
+#========================================
+# Test Counters
+#========================================
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+#========================================
+# Test Helper Functions
+#========================================
+run_test() {
+	local test_name="$1"
+	local test_func="$2"
+
+	TESTS_RUN=$((TESTS_RUN + 1))
+	echo "Running: ${test_name}"
+	
+	if ${test_func}; then
+		TESTS_PASSED=$((TESTS_PASSED + 1))
+		echo "✓ ${test_name}"
+		return 0
+	else
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+		echo "✗ ${test_name}"
+		return 1
+	fi
+}
+
+#========================================
+# Unit Tests
+#========================================
+
+test_parse_arguments_valid_phase() {
+	# Reset global variable
+	MIGRATION_PHASE=""
+
+	# Test valid phase: pre
+	parse_arguments --migration-phase pre
+	[[ "${MIGRATION_PHASE}" == "pre" ]] || return 1
+
+	# Test valid phase: post
+	MIGRATION_PHASE=""
+	parse_arguments --migration-phase post
+	[[ "${MIGRATION_PHASE}" == "post" ]] || return 1
+
+	# Test valid phase: full
+	MIGRATION_PHASE=""
+	parse_arguments --migration-phase full
+	[[ "${MIGRATION_PHASE}" == "full" ]] || return 1
+	
+	return 0
+}
+
+test_parse_arguments_invalid_phase() {
+	# Test invalid phase should fail
+	MIGRATION_PHASE=""
+	if parse_arguments --migration-phase invalid 2>/dev/null; then
+		return 1  # Should have failed
+	fi
+	
+	return 0
+}
+
+test_parse_arguments_missing_phase() {
+	# Test missing required argument should fail
+	if parse_arguments 2>/dev/null; then
+		return 1  # Should have failed
+	fi
+	
+	return 0
+}
+
+test_parse_arguments_custom_options() {
+	# Reset variables
+	MIGRATION_PHASE=""
+	FILESYSTEM_NAME="default-fs"
+	CAS_NAMESPACE="default-cas"
+	JOB_NAME="default-job"
+	JOB_TIMEOUT="1800"
+
+	# Test custom options
+	parse_arguments \
+		--migration-phase pre \
+		--filesystem-name custom-fs \
+		--cas-namespace custom-cas \
+		--job-name custom-job \
+		--timeout 3600
+	
+	[[ "${MIGRATION_PHASE}" == "pre" ]] || return 1
+	[[ "${FILESYSTEM_NAME}" == "custom-fs" ]] || return 1
+	[[ "${CAS_NAMESPACE}" == "custom-cas" ]] || return 1
+	[[ "${JOB_NAME}" == "custom-job" ]] || return 1
+	[[ "${JOB_TIMEOUT}" == "3600" ]] || return 1
+	
+	return 0
+}
+
+test_parse_arguments_flags() {
+	# Reset variables
+	MIGRATION_PHASE=""
+	SKIP_VALIDATION="false"
+	DRY_RUN="false"
+	
+	# Test boolean flags
+	parse_arguments \
+		--migration-phase pre \
+		--skip-validation \
+		--dry-run
+	
+	[[ "${SKIP_VALIDATION}" == "true" ]] || return 1
+	[[ "${DRY_RUN}" == "true" ]] || return 1
+	
+	return 0
+}
+
+test_compute_hash_valid_file() {
+	# Create a temporary test file
+	local test_file
+	test_file=$(mktemp)
+	echo "test content" > "${test_file}"
+
+	# Compute hash
+	local hash
+	hash=$(compute_script_hash "${test_file}")
+	local result=$?
+	
+	# Cleanup
+	rm -f "${test_file}"
+	
+	# Verify hash format (8 characters)
+	[[ ${result} -eq 0 ]] || return 1
+	[[ ${#hash} -eq 8 ]] || return 1
+	[[ "${hash}" =~ ^[a-f0-9]{8}$ ]] || return 1
+	
+	return 0
+}
+
+test_compute_hash_missing_file() {
+	# Test with non-existent file should fail
+	if compute_script_hash "/nonexistent/file" 2>/dev/null; then
+		return 1  # Should have failed
+	fi
+	
+	return 0
+}
+
+test_compute_hash_consistency() {
+	# Create a temporary test file
+	local test_file
+	test_file=$(mktemp)
+	echo "consistent content" > "${test_file}"
+	
+	# Compute hash twice
+	local hash1 hash2
+	hash1=$(compute_script_hash "${test_file}")
+	hash2=$(compute_script_hash "${test_file}")
+	
+	# Cleanup
+	rm -f "${test_file}"
+	
+	# Hashes should be identical for same content
+	[[ "${hash1}" == "${hash2}" ]] || return 1
+	
+	return 0
+}
+
+test_require_argument_value_valid() {
+	# Test with valid value
+	if ! require_argument_value "--test-option" "valid-value" 2>/dev/null; then
+		return 1  # Should have succeeded
+	fi
+	
+	return 0
+}
+
+test_require_argument_value_missing() {
+	# Test with missing value should fail
+	if require_argument_value "--test-option" "" 2>/dev/null; then
+		return 1  # Should have failed
+	fi
+	
+	return 0
+}
+
+test_require_argument_value_next_option() {
+	# Test with next option as value should fail
+	if require_argument_value "--test-option" "--another-option" 2>/dev/null; then
+		return 1  # Should have failed
+	fi
+	
+	return 0
+}
+
+#========================================
+# Main Test Execution
+#========================================
+main() {
+	echo "========================================="
+	echo "Running Unit Tests for migrate-data-cache.sh"
+	echo "========================================="
+	echo ""
+
+	# Argument parsing tests
+	run_test "parse_arguments: valid phases" test_parse_arguments_valid_phase || true
+	run_test "parse_arguments: invalid phase" test_parse_arguments_invalid_phase || true
+	run_test "parse_arguments: missing phase" test_parse_arguments_missing_phase || true
+	run_test "parse_arguments: custom options" test_parse_arguments_custom_options || true
+	run_test "parse_arguments: boolean flags" test_parse_arguments_flags || true
+	
+	# Hash computation tests
+	run_test "compute_hash: valid file" test_compute_hash_valid_file || true
+	run_test "compute_hash: missing file" test_compute_hash_missing_file || true
+	run_test "compute_hash: consistency" test_compute_hash_consistency || true
+	
+	# Argument validation tests
+	run_test "require_argument_value: valid" test_require_argument_value_valid || true
+	run_test "require_argument_value: missing" test_require_argument_value_missing || true
+	run_test "require_argument_value: next option" test_require_argument_value_next_option || true
+	
+	# Print summary
+	echo ""
+	echo "========================================="
+	echo "Test Summary"
+	echo "========================================="
+	echo "Tests Run:    ${TESTS_RUN}"
+	echo "Tests Passed: ${TESTS_PASSED}"
+	echo "Tests Failed: ${TESTS_FAILED}"
+	echo "========================================="
+	
+	if [[ ${TESTS_FAILED} -eq 0 ]]; then
+		echo "✅ All tests passed!"
+		return 0
+	else
+		echo "❌ Some tests failed"
+		return 1
+	fi
+}
+
+main "$@"
+
+# Made with Bob

--- a/CAS/local-data-caching/tests/test_version_utils.sh
+++ b/CAS/local-data-caching/tests/test_version_utils.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+
+# shellcheck source=lib/logging.sh
+source "$ROOT_DIR/lib/logging.sh"
+# shellcheck source=lib/utils.sh
+source "$ROOT_DIR/lib/utils.sh"
+# shellcheck source=modules/scale_utils.sh
+source "$ROOT_DIR/modules/scale_utils.sh"
+
+# ---------------------------------------------------------------------------
+# Minimal test harness
+# ---------------------------------------------------------------------------
+PASS=0
+FAIL=0
+
+assert_eq() {
+	local desc="$1"
+	local expected="$2"
+	local actual="$3"
+	if [[ "${expected}" == "${actual}" ]]; then
+		echo "  PASS: ${desc}"
+		((++PASS))
+	else
+		echo "  FAIL: ${desc} — expected '${expected}', got '${actual}'"
+		((++FAIL))
+	fi
+}
+
+# ---------------------------------------------------------------------------
+# version_gte tests
+# ---------------------------------------------------------------------------
+echo "version_gte"
+
+assert_eq "equal versions (1.1.5 >= 1.1.5)"          true  "$(version_gte "1.1.5"  "1.1.5")"
+assert_eq "patch greater (1.1.6 >= 1.1.5)"           true  "$(version_gte "1.1.6"  "1.1.5")"
+assert_eq "minor greater (1.2.0 >= 1.1.5)"           true  "$(version_gte "1.2.0"  "1.1.5")"
+assert_eq "major greater (2.0.0 >= 1.1.5)"           true  "$(version_gte "2.0.0"  "1.1.5")"
+assert_eq "patch less (1.1.4 < 1.1.5)"               false "$(version_gte "1.1.4"  "1.1.5")"
+assert_eq "minor less (1.0.9 < 1.1.5)"               false "$(version_gte "1.0.9"  "1.1.5")"
+assert_eq "major less (0.9.0 < 1.1.5)"               false "$(version_gte "0.9.0"  "1.1.5")"
+
+assert_eq "equal CNSA CSV (60.1.0 >= 60.1.0)"        true  "$(version_gte "60.1.0" "60.1.0")"
+assert_eq "CNSA patch greater (60.1.1 >= 60.1.0)"    true  "$(version_gte "60.1.1" "60.1.0")"
+assert_eq "CNSA minor greater (60.2.0 >= 60.1.0)"    true  "$(version_gte "60.2.0" "60.1.0")"
+assert_eq "CNSA less (60.0.9 < 60.1.0)"              false "$(version_gte "60.0.9" "60.1.0")"
+
+assert_eq "equal ODF (4.21 >= 4.21)"                 true  "$(version_gte "4.21"   "4.21")"
+assert_eq "ODF minor greater (4.21 >= 4.20)"         true  "$(version_gte "4.21"   "4.20")"
+assert_eq "ODF minor less (4.20 < 4.21)"             false "$(version_gte "4.20"   "4.21")"
+
+# ---------------------------------------------------------------------------
+# cnsa_product_to_csv tests
+# ---------------------------------------------------------------------------
+echo "cnsa_product_to_csv"
+
+assert_eq "6.0.0.0 -> 60.0.0"  "60.0.0" "$(cnsa_product_to_csv "6.0.0.0")"
+assert_eq "6.0.0.5 -> 60.0.5"  "60.0.5" "$(cnsa_product_to_csv "6.0.0.5")"
+assert_eq "6.0.1.0 -> 60.1.0"  "60.1.0" "$(cnsa_product_to_csv "6.0.1.0")"
+assert_eq "6.0.1.2 -> 60.1.2"  "60.1.2" "$(cnsa_product_to_csv "6.0.1.2")"
+assert_eq "6.0.2.0 -> 60.2.0"  "60.2.0" "$(cnsa_product_to_csv "6.0.2.0")"
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "Results: ${PASS} passed, ${FAIL} failed"
+[[ "${FAIL}" -eq 0 ]]

--- a/CAS/local-data-caching/tests/test_wait_for_condition.sh
+++ b/CAS/local-data-caching/tests/test_wait_for_condition.sh
@@ -10,6 +10,8 @@ PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 # Source required files
 # shellcheck source=lib/constants.sh
 source "${PROJECT_ROOT}/lib/constants.sh"
+# shellcheck source=lib/logging.sh
+source "${PROJECT_ROOT}/lib/logging.sh"
 # shellcheck source=lib/utils.sh
 source "${PROJECT_ROOT}/lib/utils.sh"
 


### PR DESCRIPTION
This PR introduces a number of fixes to the Local Data Caching scripts, including (but not limited to):

* Scripting to facilitate migrating existing installations of Local Data Caching using CAS 1.1.4 to CAS 1.1.5
  * These are a subset of the regular [upgrade instructions for CAS](https://www.ibm.com/docs/en/fusion-software/2.13.0?topic=services-upgrading-content-aware-storage-cas) in Fusion 2.13.
* Multi-version installation, allowing the same script to be used for both CAS 1.1.4 setup (on Fusion 2.12) and CAS 1.1.5+ (on Fusion 2.13+)
* Leveraging KMM integration for Scale GPFS kernel driver (CNSA 6.0.1.0+ only)