### PR TITLE
error in patch-offline-mirror

### DIFF
--- a/backup-restore/hotfixes/2.13.0/br-2.13.0patch-offline-mirror.sh
+++ b/backup-restore/hotfixes/2.13.0/br-2.13.0patch-offline-mirror.sh
@@ -45,18 +45,21 @@ build_icr_path() {
 copy_images() {
   TARGET_PATH=${1}
   for IMAGE in "${IMAGES[@]}"; do
+    [[ -z "$IMAGE" ]] && continue
     DESTINATION=docker://$TARGET_PATH/cp/bnr/$IMAGE
     echo -e "Copying\n Image: $(build_icr_path ${BNR_PREFIX} ${IMAGE})\n Destination: docker://$TARGET_PATH/cp/bnr/$IMAGE\n"
     skopeo copy --insecure-policy --preserve-digests --all docker://"$BNR_PREFIX"/"$IMAGE" "$DESTINATION"
   done
 
   for FUSIONHCIIMAGE in "${FUSIONIMAGES_HCI[@]}"; do
+    [[ -z "$FUSIONHCIIMAGE" ]] && continue
     DESTINATION=docker://$TARGET_PATH/cp/fusion-hci/$FUSIONHCIIMAGE
     echo -e "Copying\n Image: $(build_icr_path ${HCI_PREFIX} ${FUSIONHCIIMAGE})\n Destination: docker://$TARGET_PATH/cp/fusion-hci/$FUSIONHCIIMAGE\n"
     skopeo copy --insecure-policy --preserve-digests --all docker://"$HCI_PREFIX"/"$FUSIONHCIIMAGE" "$DESTINATION"
   done
 
   for FUSIONSDSIMAGE in "${FUSIONIMAGES_SDS[@]}"; do
+    [[ -z "$FUSIONSDSIMAGE" ]] && continue
     DESTINATION=docker://$TARGET_PATH/cp/fusion-sds/$FUSIONSDSIMAGE
     echo -e "Copying\n Image: $(build_icr_path ${SDS_PREFIX} ${FUSIONSDSIMAGE})\n Destination: docker://$TARGET_PATH/cp/fusion-sds/$FUSIONSDSIMAGE\n"
     skopeo copy --insecure-policy --preserve-digests --all docker://"$SDS_PREFIX"/"$FUSIONSDSIMAGE" "$DESTINATION"


### PR DESCRIPTION
Patch mirror script fails:
```
Writing manifest list to image destination
Storing list signatures
Copying
 Image: cp.icr.io/cp/fusion-hci/
 Destination: docker://us-docker.pkg.dev/gcp-dct-ccca-dev/ccca-d-image-registry/cp/fusion-hci/

time="2026-08-20T08:09:20Z" level=fatal msg="Invalid source name docker://cp.icr.io/cp/fusion-hci/: invalid reference format"
```